### PR TITLE
リロード時に履歴が引き継がれないバグの修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 src/js/*
 .vscode/settings.json
 .idea/*
+.DS_Store

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,7 @@
 		<link href="https://fonts.googleapis.com/css?family=MedievalSharp&amp;subset=latin-ext" rel="stylesheet" />
 	</head>
 
-	<body class="container bg-dark text-white h-100" style="font-family: 'MedievalSharp', cursive">
+	<body class="bg-dark text-white" style="font-family: 'MedievalSharp', cursive">
 		<div class="row">
 			<section class="col-sm text-center">
 				<p id="bingo-number" style="font-size: 55vmin"></p>

--- a/src/index.html
+++ b/src/index.html
@@ -7,13 +7,13 @@
 		<meta name="description" content="Bingo Machine" />
 		<meta name="author" content="ROhta" />
 		<meta name="robots" content="noindex, nofollow" />
-		<meta property="og:title" content="Bingo Machine">
-		<meta property="og:description" content="A Bingo Machine for Party">
-		<meta property="og:site_name" content="Bingo Machine">
-		<meta property="og:url" content="https://rohta.github.io/bingo/">
-		<meta property="og:image" content="https://rohta.github.io/bingo/materials/ogp.png">
-		<meta property="og:locale" content="ja_JP">
-		<meta property="og:type" content="game">
+		<meta property="og:title" content="Bingo Machine" />
+		<meta property="og:description" content="A Bingo Machine for Party" />
+		<meta property="og:site_name" content="Bingo Machine" />
+		<meta property="og:url" content="https://rohta.github.io/bingo/" />
+		<meta property="og:image" content="https://rohta.github.io/bingo/materials/ogp.png" />
+		<meta property="og:locale" content="ja_JP" />
+		<meta property="og:type" content="game" />
 		<title>Bingo Machine</title>
 		<link rel="icon" href="./materials/logo.ico" />
 		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous" />

--- a/src/ts/domManipulation.ts
+++ b/src/ts/domManipulation.ts
@@ -53,7 +53,10 @@ class DomManipulation {
 		if (typeof choosedNumber === "number") {
 			remains.splice(i, 1)
 			this._numbers.remainList = remains
-			this._numbers.historyList.push(choosedNumber)
+
+			const histories = this._numbers.historyList
+			histories.push(choosedNumber)
+			this._numbers.historyList = histories
 
 			this._bingoNumber.innerHTML = this.zeroPad(choosedNumber)
 			this.addHistory(choosedNumber)

--- a/src/ts/domManipulation.ts
+++ b/src/ts/domManipulation.ts
@@ -37,10 +37,10 @@ class DomManipulation {
 	private zeroPad = (n: number): string => String(n).padStart(2, "0")
 
 	private addHistory = (n: number): void => {
-		const historyNumber = document.createElement("p")
-		historyNumber.className = this._historyDisplayClassName
-		historyNumber.innerHTML = this.zeroPad(n)
-		this._historyDisplay.appendChild(historyNumber)
+		const historyNumberElement = document.createElement("p")
+		historyNumberElement.className = this._historyDisplayClassName
+		historyNumberElement.innerHTML = this.zeroPad(n)
+		this._historyDisplay.appendChild(historyNumberElement)
 	}
 
 	private chooseNumber = (): void => {
@@ -74,9 +74,9 @@ class DomManipulation {
 	private playRoulette = (): void => {
 		if (!this._isStarted) return
 		if (this._drum.currentTime < this._drum.duration) {
-			const choosedNumber = this._numbers.remainList[this._numbers.generateRandomNumber(this._numbers.remainList.length)]
-			if (typeof choosedNumber === "number") {
-				this._bingoNumber.innerHTML = this.zeroPad(choosedNumber)
+			const rouletteNumber = this._numbers.remainList[this._numbers.generateRandomNumber(this._numbers.remainList.length)]
+			if (typeof rouletteNumber === "number") {
+				this._bingoNumber.innerHTML = this.zeroPad(rouletteNumber)
 			} else {
 				throw new Error("Something is wrong with localStorage!")
 			}

--- a/src/ts/numberList.ts
+++ b/src/ts/numberList.ts
@@ -13,16 +13,16 @@ class NumberList {
 		return this.getListFromLocalStorage(this._remainListKey)
 	}
 
-	set remainList(remains: number[]) {
-		this.setListOnLocalStorage(this._remainListKey, remains)
+	set remainList(remainsList: number[]) {
+		this.setListOnLocalStorage(this._remainListKey, remainsList)
 	}
 
 	get historyList(): number[] {
 		return this.getListFromLocalStorage(this._historyListKey)
 	}
 
-	set historyList(histories: number[]) {
-		this.setListOnLocalStorage(this._historyListKey, histories)
+	set historyList(historiesList: number[]) {
+		this.setListOnLocalStorage(this._historyListKey, historiesList)
 	}
 
 	private getListFromLocalStorage(key: string): number[] {


### PR DESCRIPTION
## 期待する挙動・状態

- 数回ビンゴを回した後リロードしても、Hit Numbersに値が表示されること
- 横に長いディスプレイでも、数字選択部と履歴表示部が画面の左右で半分ずつの表示面積を占めること

## 必要な依存関係

- なし

## 確認済み項目

- [x] バグが治っていること

## 見てほしいところ

- 変数名が分かりにくくないか、history的な変数名が散らばっている
- 縦横比が正方形に近いディスプレイになるに従って、数字選択時に要素が左右移動するようになる
