### PR TITLE
Dependabot auto-merge workflow追加

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,6 +17,9 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1.0.2-beta9
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
       - name: Resolve PR number
         id: pr
         env:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.actor.login == 'dependabot[bot]'
+      github.event.workflow_run.triggering_actor.login == 'dependabot[bot]'
     timeout-minutes: 3
     permissions:
       contents: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,25 +29,10 @@ jobs:
             exit 0
           fi
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-      - name: Dependabot metadata
-        id: metadata
-        if: steps.pr.outputs.number != ''
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-        run: |
-          COMMIT_MSG=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json commits --jq '.commits | last | .messageBody')
-          if echo "$COMMIT_MSG" | grep -qF 'update-type: version-update:semver-major'; then
-            echo "update-type=version-update:semver-major" >> "$GITHUB_OUTPUT"
-          else
-            echo "update-type=" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Enable auto-merge
-        if: >-
-          steps.pr.outputs.number != '' &&
-          steps.metadata.outputs.update-type != 'version-update:semver-major'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-        run: gh pr merge --auto --squash "$PR_NUMBER"
+      - if: steps.pr.outputs.number != ''
+        uses: fastify/github-action-merge-dependabot@30c3f8f14a4f7b315ba38dbc1b793d27128fef82 # v3.12.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.pr.outputs.number }}
+          target: minor
+          use-github-auto-merge: true

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,22 @@
+name: Dependabot Auto-merge
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  Auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    timeout-minutes: 3
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+      - name: Enable auto-merge
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -32,9 +32,17 @@ jobs:
       - name: Dependabot metadata
         id: metadata
         if: steps.pr.outputs.number != ''
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          COMMIT_MSG=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json commits --jq '.commits | last | .messageBody')
+          if echo "$COMMIT_MSG" | grep -qF 'update-type: version-update:semver-major'; then
+            echo "update-type=version-update:semver-major" >> "$GITHUB_OUTPUT"
+          else
+            echo "update-type=" >> "$GITHUB_OUTPUT"
+          fi
       - name: Enable auto-merge
         if: >-
           steps.pr.outputs.number != '' &&

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,22 +1,45 @@
 name: Dependabot Auto-merge
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Dependency Check"]
+    types:
+      - completed
+
 jobs:
   Auto-merge:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
     timeout-minutes: 3
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-      - name: Enable auto-merge
+      - name: Resolve PR number
+        id: pr
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --auto --squash "$PR_URL"
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$HEAD_BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR found for branch $HEAD_BRANCH"
+            exit 0
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+      - name: Dependabot metadata
+        id: metadata
+        if: steps.pr.outputs.number != ''
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge
+        if: >-
+          steps.pr.outputs.number != '' &&
+          steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr merge --auto --squash "$PR_NUMBER"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,7 +1,7 @@
 name: Dependency Check
 on:
   pull_request:
-    types: [review_requested, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, review_requested, ready_for_review]
     branches:
       - main
 jobs:
@@ -11,7 +11,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - if: github.actor != 'dependabot[bot]'
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v6
@@ -24,7 +25,8 @@ jobs:
     timeout-minutes: 3
     permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - if: github.actor != 'dependabot[bot]'
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v6


### PR DESCRIPTION
## 期待する挙動・状態

- Dependabotが作成したPRが、CI通過後に自動でsquash mergeされるようになる
- ROhtaの手動レビュー/承認なしで完結する

## 必要な依存関係

- main branchのRuleset 724490の `bypass_actors` にDependabot Integration (App ID: 29110, bypass_mode: pull_request) を追加済み
  - CODEOWNERS (`* @ROhta`) と `require_code_owner_review: true` の組み合わせで毎回ROhtaのレビューが要求されていた問題への対処
  - 通常PR（人間のPR）には影響なし。Dependabotが作成したPRに限定してRulesetをbypass

## 確認済み項目

- [x] `gh api /apps/dependabot` でApp ID=29110を確認
- [x] Ruleset変更後に `bypass_actors` にDependabotが追加されていることを確認
- [x] workflowはコマンドインジェクション対策として `env:` 経由でPR URLを渡している
- [x] 既存workflow群と同様に `actions-permissions/monitor` で権限を可視化

## 見てほしいところ

- [x] PRのLabelsの設定は適切か
- [x] 次のdependabot PRが自動マージされるか実地検証