### PR TITLE
TypeScript/HTML をモダン記法へ刷新

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -41,12 +41,12 @@
 		<!-- End Google Tag Manager (noscript) -->
 		<main class="row">
 			<h1 class="visually-hidden">Bingo Machine</h1>
-			<section class="col-sm text-center">
+			<section class="col-sm text-center" aria-label="ビンゴ抽選">
 				<p id="bingo-number" style="font-size: 55vmin">00</p>
-				<button type="button" id="start-button" class="btn btn-lg btn-secondary px-5 py-4" autofocus aria-pressed="false">START</button>
+				<button type="button" id="start-button" class="btn btn-lg btn-secondary px-5 py-4" autofocus aria-pressed="false" aria-controls="bingo-number">START</button>
 				<button type="button" id="reset-button" class="btn btn-lg btn-secondary px-1 py-4" commandfor="reset-confirm" command="show-modal">RESET</button>
 			</section>
-			<section class="col-sm h1">
+			<section class="col-sm h1" aria-labelledby="history-title">
 				<h2 id="history-title" class="py-5">Hit Numbers</h2>
 				<ol id="history-display" class="row list-unstyled"></ol>
 			</section>

--- a/src/index.html
+++ b/src/index.html
@@ -42,7 +42,7 @@
 		<main class="row">
 			<section class="col-sm text-center">
 				<p id="bingo-number" style="font-size: 55vmin">00</p>
-				<button type="button" id="start-button" class="btn btn-lg btn-secondary px-5 py-4" autofocus>START</button>
+				<button type="button" id="start-button" class="btn btn-lg btn-secondary px-5 py-4" autofocus aria-pressed="false">START</button>
 				<button type="button" id="reset-button" class="btn btn-lg btn-secondary px-1 py-4" commandfor="reset-confirm" command="show-modal">RESET</button>
 			</section>
 			<section class="col-sm h1">

--- a/src/index.html
+++ b/src/index.html
@@ -51,8 +51,8 @@
 			</section>
 		</div>
 
-		<dialog id="reset-confirm" class="text-dark p-4">
-			<p>Do you really want to reset?</p>
+		<dialog id="reset-confirm" class="text-dark p-4" aria-labelledby="reset-confirm-title">
+			<p id="reset-confirm-title">Do you really want to reset?</p>
 			<form method="dialog" class="d-flex gap-2 justify-content-end m-0">
 				<button value="cancel" type="submit" class="btn btn-secondary">Cancel</button>
 				<button value="ok" type="submit" class="btn btn-danger">OK</button>

--- a/src/index.html
+++ b/src/index.html
@@ -40,19 +40,20 @@
 		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NHDWG63" height="0" width="0" hidden></iframe></noscript>
 		<!-- End Google Tag Manager (noscript) -->
 		<main class="row">
+			<h1 class="visually-hidden">Bingo Machine</h1>
 			<section class="col-sm text-center">
 				<p id="bingo-number" style="font-size: 55vmin">00</p>
 				<button type="button" id="start-button" class="btn btn-lg btn-secondary px-5 py-4" autofocus aria-pressed="false">START</button>
 				<button type="button" id="reset-button" class="btn btn-lg btn-secondary px-1 py-4" commandfor="reset-confirm" command="show-modal">RESET</button>
 			</section>
 			<section class="col-sm h1">
-				<p id="history-title" class="py-5">Hit Numbers</p>
+				<h2 id="history-title" class="py-5">Hit Numbers</h2>
 				<ol id="history-display" class="row list-unstyled"></ol>
 			</section>
 		</main>
 
 		<dialog id="reset-confirm" class="text-dark p-4" aria-labelledby="reset-confirm-title" closedby="closerequest">
-			<p id="reset-confirm-title">Do you really want to reset?</p>
+			<h2 id="reset-confirm-title" class="h5">Do you really want to reset?</h2>
 			<form method="dialog" class="d-flex gap-2 justify-content-end m-0">
 				<button value="cancel" type="submit" class="btn btn-secondary">Cancel</button>
 				<button value="ok" type="submit" class="btn btn-danger">OK</button>

--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,6 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
-	<head prefix="og:http://ogp.me/ns#">
+	<head>
 		<!-- Google Tag Manager -->
 		<script>
 			;(function (w, d, s, l, i) {
@@ -16,8 +16,7 @@
 		</script>
 		<!-- End Google Tag Manager -->
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1.0" />
-		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="description" content="Bingo Machine" />
 		<meta name="author" content="ROhta" />
 		<meta name="robots" content="noindex, nofollow" />
@@ -31,14 +30,14 @@
 		<title>Bingo Machine</title>
 		<link rel="icon" href="./materials/logo.ico" />
 		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous" />
-		<link rel="preconnect" href="https://fonts.googleapis.com">
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-		<link href="https://fonts.googleapis.com/css2?family=MedievalSharp&display=swap" rel="stylesheet">
+		<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+		<link href="https://fonts.googleapis.com/css2?family=MedievalSharp&display=swap" rel="stylesheet" />
 	</head>
 
-	<body class="bg-dark text-white" style="font-family: 'MedievalSharp', cursive">
+	<body class="bg-dark text-white" style="font-family: &quot;MedievalSharp&quot;, cursive">
 		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NHDWG63" height="0" width="0" style="display: none; visibility: hidden"></iframe></noscript>
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NHDWG63" height="0" width="0" hidden></iframe></noscript>
 		<!-- End Google Tag Manager (noscript) -->
 		<div class="row">
 			<section class="col-sm text-center">
@@ -52,10 +51,18 @@
 			</section>
 		</div>
 
+		<dialog id="reset-confirm" class="text-dark p-4">
+			<p>Do you really want to reset?</p>
+			<form method="dialog" class="d-flex gap-2 justify-content-end m-0">
+				<button value="cancel" type="submit" class="btn btn-secondary">Cancel</button>
+				<button value="ok" type="submit" class="btn btn-danger">OK</button>
+			</form>
+		</dialog>
+
 		<audio id="drum" preload="auto" src="./materials/drumroll.mp3"></audio>
 		<audio id="cymbals" preload="auto" src="./materials/cymbals.mp3"></audio>
 
 		<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
-		<script type="module" src="./js/index.js" defer></script>
+		<script type="module" src="./js/index.js"></script>
 	</body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -41,12 +41,12 @@
 		<!-- End Google Tag Manager (noscript) -->
 		<main class="row">
 			<section class="col-sm text-center">
-				<p id="bingo-number" style="font-size: 55vmin"></p>
-				<button type="button" id="start-button" class="btn btn-lg btn-secondary px-5 py-4" autofocus></button>
-				<button type="button" id="reset-button" class="btn btn-lg btn-secondary px-1 py-4"></button>
+				<p id="bingo-number" style="font-size: 55vmin">00</p>
+				<button type="button" id="start-button" class="btn btn-lg btn-secondary px-5 py-4" autofocus>START</button>
+				<button type="button" id="reset-button" class="btn btn-lg btn-secondary px-1 py-4">RESET</button>
 			</section>
 			<section class="col-sm h1">
-				<p id="history-title" class="py-5"></p>
+				<p id="history-title" class="py-5">Hit Numbers</p>
 				<div id="history-display" class="row"></div>
 			</section>
 		</main>

--- a/src/index.html
+++ b/src/index.html
@@ -47,7 +47,7 @@
 			</section>
 			<section class="col-sm h1">
 				<p id="history-title" class="py-5">Hit Numbers</p>
-				<div id="history-display" class="row"></div>
+				<ol id="history-display" class="row list-unstyled"></ol>
 			</section>
 		</main>
 

--- a/src/index.html
+++ b/src/index.html
@@ -37,26 +37,29 @@
 
 	<body class="bg-dark text-white" style="font-family: &quot;MedievalSharp&quot;, cursive">
 		<!-- Google Tag Manager (noscript) -->
-		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NHDWG63" height="0" width="0" hidden></iframe></noscript>
+		<noscript>
+			<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NHDWG63" height="0" width="0" hidden></iframe>
+			<p class="text-center p-4">このビンゴマシンは JavaScript を必要とします。ブラウザの設定で有効化してください。</p>
+		</noscript>
 		<!-- End Google Tag Manager (noscript) -->
 		<main class="row">
-			<h1 class="visually-hidden">Bingo Machine</h1>
+			<h1 lang="en" class="visually-hidden">Bingo Machine</h1>
 			<section class="col-sm text-center" aria-label="ビンゴ抽選">
 				<p id="bingo-number" style="font-size: 55vmin">00</p>
-				<button type="button" id="start-button" class="btn btn-lg btn-secondary px-5 py-4" autofocus aria-pressed="false" aria-controls="bingo-number">START</button>
-				<button type="button" id="reset-button" class="btn btn-lg btn-secondary px-1 py-4" commandfor="reset-confirm" command="show-modal">RESET</button>
+				<button type="button" id="start-button" lang="en" class="btn btn-lg btn-secondary px-5 py-4" autofocus aria-pressed="false" aria-controls="bingo-number">START</button>
+				<button type="button" id="reset-button" lang="en" class="btn btn-lg btn-secondary px-1 py-4" commandfor="reset-confirm" command="show-modal">RESET</button>
 			</section>
 			<section class="col-sm h1" aria-labelledby="history-title">
-				<h2 id="history-title" class="py-5">Hit Numbers</h2>
+				<h2 lang="en" id="history-title" class="py-5">Hit Numbers</h2>
 				<ol id="history-display" class="row list-unstyled"></ol>
 			</section>
 		</main>
 
 		<dialog id="reset-confirm" class="text-dark p-4" aria-labelledby="reset-confirm-title" closedby="closerequest">
-			<h2 id="reset-confirm-title" class="h5">Do you really want to reset?</h2>
+			<h2 lang="en" id="reset-confirm-title" class="h5">Do you really want to reset?</h2>
 			<form method="dialog" class="d-flex gap-2 justify-content-end m-0">
-				<button value="cancel" type="submit" class="btn btn-secondary">Cancel</button>
-				<button value="ok" type="submit" class="btn btn-danger">OK</button>
+				<button value="cancel" lang="en" type="submit" class="btn btn-secondary">Cancel</button>
+				<button value="ok" lang="en" type="submit" class="btn btn-danger">OK</button>
 			</form>
 		</dialog>
 

--- a/src/index.html
+++ b/src/index.html
@@ -39,19 +39,19 @@
 		<!-- Google Tag Manager (noscript) -->
 		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NHDWG63" height="0" width="0" hidden></iframe></noscript>
 		<!-- End Google Tag Manager (noscript) -->
-		<div class="row">
+		<main class="row">
 			<section class="col-sm text-center">
 				<p id="bingo-number" style="font-size: 55vmin"></p>
-				<button type="button" id="start-button" class="btn btn-lg btn-secondary px-5 py-4"></button>
+				<button type="button" id="start-button" class="btn btn-lg btn-secondary px-5 py-4" autofocus></button>
 				<button type="button" id="reset-button" class="btn btn-lg btn-secondary px-1 py-4"></button>
 			</section>
 			<section class="col-sm h1">
 				<p id="history-title" class="py-5"></p>
 				<div id="history-display" class="row"></div>
 			</section>
-		</div>
+		</main>
 
-		<dialog id="reset-confirm" class="text-dark p-4" aria-labelledby="reset-confirm-title">
+		<dialog id="reset-confirm" class="text-dark p-4" aria-labelledby="reset-confirm-title" closedby="closerequest">
 			<p id="reset-confirm-title">Do you really want to reset?</p>
 			<form method="dialog" class="d-flex gap-2 justify-content-end m-0">
 				<button value="cancel" type="submit" class="btn btn-secondary">Cancel</button>

--- a/src/index.html
+++ b/src/index.html
@@ -43,7 +43,7 @@
 			<section class="col-sm text-center">
 				<p id="bingo-number" style="font-size: 55vmin">00</p>
 				<button type="button" id="start-button" class="btn btn-lg btn-secondary px-5 py-4" autofocus>START</button>
-				<button type="button" id="reset-button" class="btn btn-lg btn-secondary px-1 py-4">RESET</button>
+				<button type="button" id="reset-button" class="btn btn-lg btn-secondary px-1 py-4" commandfor="reset-confirm" command="show-modal">RESET</button>
 			</section>
 			<section class="col-sm h1">
 				<p id="history-title" class="py-5">Hit Numbers</p>

--- a/src/ts/domManipulation.ts
+++ b/src/ts/domManipulation.ts
@@ -9,14 +9,14 @@ export default class DomManipulation {
 	readonly #stopText = "STOP"
 	readonly #bingoNumber: HTMLParagraphElement
 	readonly #startButton: HTMLButtonElement
-	readonly #historyDisplay: HTMLDivElement
+	readonly #historyDisplay: HTMLOListElement
 	readonly #historyDisplayClassName: string
 	readonly #drum: HTMLAudioElement
 	readonly #cymbals: HTMLAudioElement
 	readonly #resetDialog: HTMLDialogElement
 	readonly #rouletteInterval: number
 
-	constructor(bingoNumber: HTMLParagraphElement, startButton: HTMLButtonElement, historyDisplay: HTMLDivElement, historyDisplayClassName: string, drum: HTMLAudioElement, cymbals: HTMLAudioElement, resetDialog: HTMLDialogElement, rouletteInterval: number) {
+	constructor(bingoNumber: HTMLParagraphElement, startButton: HTMLButtonElement, historyDisplay: HTMLOListElement, historyDisplayClassName: string, drum: HTMLAudioElement, cymbals: HTMLAudioElement, resetDialog: HTMLDialogElement, rouletteInterval: number) {
 		if (rouletteInterval <= 0) console.error("Interval should be natural number!")
 
 		this.#bingoNumber = bingoNumber
@@ -42,7 +42,7 @@ export default class DomManipulation {
 	#zeroPad = (n: number): string => String(n).padStart(2, "0")
 
 	#addHistory = (n: number): void => {
-		const historyNumberElement = document.createElement("p")
+		const historyNumberElement = document.createElement("li")
 		historyNumberElement.className = this.#historyDisplayClassName
 		historyNumberElement.textContent = this.#zeroPad(n)
 		this.#historyDisplay.append(historyNumberElement)

--- a/src/ts/domManipulation.ts
+++ b/src/ts/domManipulation.ts
@@ -7,12 +7,8 @@ export default class DomManipulation {
 	readonly #firstDisplayNumber = "00"
 	readonly #startText = "START"
 	readonly #stopText = "STOP"
-	readonly #resetText = "RESET"
-	readonly #historyTitleText = "Hit Numbers"
 	readonly #bingoNumber: HTMLParagraphElement
 	readonly #startButton: HTMLButtonElement
-	readonly #resetButton: HTMLButtonElement
-	readonly #historyTitle: HTMLParagraphElement
 	readonly #historyDisplay: HTMLDivElement
 	readonly #historyDisplayClassName: string
 	readonly #drum: HTMLAudioElement
@@ -20,24 +16,17 @@ export default class DomManipulation {
 	readonly #resetDialog: HTMLDialogElement
 	readonly #rouletteInterval: number
 
-	constructor(bingoNumber: HTMLParagraphElement, startButton: HTMLButtonElement, resetButton: HTMLButtonElement, historyTitle: HTMLParagraphElement, historyDisplay: HTMLDivElement, historyDisplayClassName: string, drum: HTMLAudioElement, cymbals: HTMLAudioElement, resetDialog: HTMLDialogElement, rouletteInterval: number) {
+	constructor(bingoNumber: HTMLParagraphElement, startButton: HTMLButtonElement, historyDisplay: HTMLDivElement, historyDisplayClassName: string, drum: HTMLAudioElement, cymbals: HTMLAudioElement, resetDialog: HTMLDialogElement, rouletteInterval: number) {
 		if (rouletteInterval <= 0) console.error("Interval should be natural number!")
 
 		this.#bingoNumber = bingoNumber
 		this.#startButton = startButton
-		this.#resetButton = resetButton
-		this.#historyTitle = historyTitle
 		this.#historyDisplay = historyDisplay
 		this.#historyDisplayClassName = historyDisplayClassName
 		this.#drum = drum
 		this.#cymbals = cymbals
 		this.#resetDialog = resetDialog
 		this.#rouletteInterval = rouletteInterval
-
-		this.#bingoNumber.textContent = this.#firstDisplayNumber
-		this.#startButton.textContent = this.#startText
-		this.#resetButton.textContent = this.#resetText
-		this.#historyTitle.textContent = this.#historyTitleText
 
 		if (this.#numbers.remainList.length === 0 && this.#numbers.historyList.length === 0) {
 			this.#numbers.resetLists()

--- a/src/ts/domManipulation.ts
+++ b/src/ts/domManipulation.ts
@@ -28,6 +28,10 @@ export default class DomManipulation {
 		this.#resetDialog = resetDialog
 		this.#rouletteInterval = rouletteInterval
 
+		this.#resetDialog.addEventListener("close", () => {
+			if (this.#resetDialog.returnValue === "ok") this.#performReset()
+		})
+
 		if (this.#numbers.remainList.length === 0 && this.#numbers.historyList.length === 0) {
 			this.#numbers.resetLists()
 		} else {
@@ -46,11 +50,16 @@ export default class DomManipulation {
 
 	#wait = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 
-	#askReset = (): Promise<boolean> =>
-		new Promise(resolve => {
-			this.#resetDialog.addEventListener("close", () => resolve(this.#resetDialog.returnValue === "ok"), {once: true})
-			this.#resetDialog.showModal()
-		})
+	#performReset = (): void => {
+		this.#numbers.resetLists()
+		this.#isStarted = false
+
+		this.#historyDisplay.replaceChildren()
+		this.#drum.pause()
+		this.#startButton.textContent = this.#startText
+		this.#bingoNumber.textContent = this.#firstDisplayNumber
+		this.#startButton.focus()
+	}
 
 	#chooseNumber = (): void => {
 		if (!this.#isStarted) return
@@ -116,17 +125,5 @@ export default class DomManipulation {
 		} catch (e: unknown) {
 			if (e instanceof Error) console.error(e.name, e.message, e.stack)
 		}
-	}
-
-	resetButtonAction = async (): Promise<void> => {
-		if (!(await this.#askReset())) return
-		this.#numbers.resetLists()
-		this.#isStarted = false
-
-		this.#historyDisplay.replaceChildren()
-		this.#drum.pause()
-		this.#startButton.textContent = this.#startText
-		this.#bingoNumber.textContent = this.#firstDisplayNumber
-		this.#startButton.focus()
 	}
 }

--- a/src/ts/domManipulation.ts
+++ b/src/ts/domManipulation.ts
@@ -86,7 +86,9 @@ export default class DomManipulation {
 
 		this.#drum.pause()
 		this.#cymbals.currentTime = 0
-		this.#cymbals.play()
+		void this.#cymbals.play().catch((e: unknown) => {
+			if (e instanceof Error) console.error(e.name, e.message, e.stack)
+		})
 
 		this.#isStarted = false
 	}
@@ -115,7 +117,9 @@ export default class DomManipulation {
 
 		this.#cymbals.pause()
 		this.#drum.currentTime = 0
-		this.#drum.play()
+		void this.#drum.play().catch((e: unknown) => {
+			if (e instanceof Error) console.error(e.name, e.message, e.stack)
+		})
 
 		this.#isStarted = true
 		try {

--- a/src/ts/domManipulation.ts
+++ b/src/ts/domManipulation.ts
@@ -57,6 +57,7 @@ export default class DomManipulation {
 		this.#historyDisplay.replaceChildren()
 		this.#drum.pause()
 		this.#startButton.textContent = this.#startText
+		this.#startButton.setAttribute("aria-pressed", "false")
 		this.#bingoNumber.textContent = this.#firstDisplayNumber
 		this.#startButton.focus()
 	}
@@ -64,6 +65,7 @@ export default class DomManipulation {
 	#chooseNumber = (): void => {
 		if (!this.#isStarted) return
 		this.#startButton.textContent = this.#startText
+		this.#startButton.setAttribute("aria-pressed", "false")
 
 		const remains = this.#numbers.remainList
 		const i = this.#numbers.generateRandomNumber(remains.length)
@@ -112,6 +114,7 @@ export default class DomManipulation {
 			return
 		}
 		this.#startButton.textContent = this.#stopText
+		this.#startButton.setAttribute("aria-pressed", "true")
 
 		this.#cymbals.pause()
 		this.#drum.currentTime = 0

--- a/src/ts/domManipulation.ts
+++ b/src/ts/domManipulation.ts
@@ -17,9 +17,10 @@ export default class DomManipulation {
 	readonly #historyDisplayClassName: string
 	readonly #drum: HTMLAudioElement
 	readonly #cymbals: HTMLAudioElement
+	readonly #resetDialog: HTMLDialogElement
 	readonly #rouletteInterval: number
 
-	constructor(bingoNumber: HTMLParagraphElement, startButton: HTMLButtonElement, resetButton: HTMLButtonElement, historyTitle: HTMLParagraphElement, historyDisplay: HTMLDivElement, historyDisplayClassName: string, drum: HTMLAudioElement, cymbals: HTMLAudioElement, rouletteInterval: number) {
+	constructor(bingoNumber: HTMLParagraphElement, startButton: HTMLButtonElement, resetButton: HTMLButtonElement, historyTitle: HTMLParagraphElement, historyDisplay: HTMLDivElement, historyDisplayClassName: string, drum: HTMLAudioElement, cymbals: HTMLAudioElement, resetDialog: HTMLDialogElement, rouletteInterval: number) {
 		if (rouletteInterval <= 0) console.error("Interval should be natural number!")
 
 		this.#bingoNumber = bingoNumber
@@ -30,12 +31,13 @@ export default class DomManipulation {
 		this.#historyDisplayClassName = historyDisplayClassName
 		this.#drum = drum
 		this.#cymbals = cymbals
+		this.#resetDialog = resetDialog
 		this.#rouletteInterval = rouletteInterval
 
-		this.#bingoNumber.innerHTML = this.#firstDisplayNumber
-		this.#startButton.innerHTML = this.#startText
-		this.#resetButton.innerHTML = this.#resetText
-		this.#historyTitle.innerHTML = this.#historyTitleText
+		this.#bingoNumber.textContent = this.#firstDisplayNumber
+		this.#startButton.textContent = this.#startText
+		this.#resetButton.textContent = this.#resetText
+		this.#historyTitle.textContent = this.#historyTitleText
 
 		if (this.#numbers.remainList.length === 0 && this.#numbers.historyList.length === 0) {
 			this.#numbers.resetLists()
@@ -49,13 +51,21 @@ export default class DomManipulation {
 	#addHistory = (n: number): void => {
 		const historyNumberElement = document.createElement("p")
 		historyNumberElement.className = this.#historyDisplayClassName
-		historyNumberElement.innerHTML = this.#zeroPad(n)
-		this.#historyDisplay.appendChild(historyNumberElement)
+		historyNumberElement.textContent = this.#zeroPad(n)
+		this.#historyDisplay.append(historyNumberElement)
 	}
+
+	#wait = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+	#askReset = (): Promise<boolean> =>
+		new Promise(resolve => {
+			this.#resetDialog.addEventListener("close", () => resolve(this.#resetDialog.returnValue === "ok"), {once: true})
+			this.#resetDialog.showModal()
+		})
 
 	#chooseNumber = (): void => {
 		if (!this.#isStarted) return
-		this.#startButton.innerHTML = this.#startText
+		this.#startButton.textContent = this.#startText
 
 		const remains = this.#numbers.remainList
 		const i = this.#numbers.generateRandomNumber(remains.length)
@@ -68,7 +78,7 @@ export default class DomManipulation {
 			histories.push(choosedNumber)
 			this.#numbers.historyList = histories
 
-			this.#bingoNumber.innerHTML = this.#zeroPad(choosedNumber)
+			this.#bingoNumber.textContent = this.#zeroPad(choosedNumber)
 			this.#addHistory(choosedNumber)
 		} else {
 			throw new Error("Index out of bounds. Check the method!")
@@ -81,54 +91,49 @@ export default class DomManipulation {
 		this.#isStarted = false
 	}
 
-	#playRoulette = (): void => {
-		if (!this.#isStarted) return
-		if (this.#drum.currentTime < this.#drum.duration) {
+	#playRoulette = async (): Promise<void> => {
+		while (this.#isStarted && this.#drum.currentTime < this.#drum.duration) {
 			const rouletteNumber = this.#numbers.remainList.at(this.#numbers.generateRandomNumber(this.#numbers.remainList.length))
-			if (typeof rouletteNumber === "number") {
-				this.#bingoNumber.innerHTML = this.#zeroPad(rouletteNumber)
-			} else {
-				throw new Error("Something is wrong with localStorage!")
-			}
-			setTimeout(this.#playRoulette, this.#rouletteInterval)
-		} else {
-			try {
-				this.#chooseNumber()
-			} catch (e: unknown) {
-				if (e instanceof Error) throw new Error(e.message, {cause: e})
-			}
+			if (typeof rouletteNumber !== "number") throw new Error("Something is wrong with localStorage!")
+			this.#bingoNumber.textContent = this.#zeroPad(rouletteNumber)
+			await this.#wait(this.#rouletteInterval)
+		}
+		if (!this.#isStarted) return
+		try {
+			this.#chooseNumber()
+		} catch (e: unknown) {
+			if (e instanceof Error) throw new Error(e.message, {cause: e})
 		}
 	}
 
-	rouletteButtonAction = (): void => {
+	rouletteButtonAction = async (): Promise<void> => {
 		if (this.#isStarted) {
 			this.#chooseNumber()
-		} else {
-			this.#startButton.innerHTML = this.#stopText
+			return
+		}
+		this.#startButton.textContent = this.#stopText
 
-			this.#cymbals.pause()
-			this.#drum.currentTime = 0
-			this.#drum.play()
+		this.#cymbals.pause()
+		this.#drum.currentTime = 0
+		this.#drum.play()
 
-			this.#isStarted = true
-			try {
-				this.#playRoulette()
-			} catch (e: unknown) {
-				if (e instanceof Error) console.error(e.name, e.message, e.stack)
-			}
+		this.#isStarted = true
+		try {
+			await this.#playRoulette()
+		} catch (e: unknown) {
+			if (e instanceof Error) console.error(e.name, e.message, e.stack)
 		}
 	}
 
-	resetButtonAction = (): void => {
-		if (confirm("Do you really want to reset?")) {
-			this.#numbers.resetLists()
-			this.#isStarted = false
+	resetButtonAction = async (): Promise<void> => {
+		if (!(await this.#askReset())) return
+		this.#numbers.resetLists()
+		this.#isStarted = false
 
-			this.#historyDisplay.innerHTML = ""
-			this.#drum.pause()
-			this.#startButton.innerHTML = this.#startText
-			this.#bingoNumber.innerHTML = this.#firstDisplayNumber
-			this.#startButton.focus()
-		}
+		this.#historyDisplay.replaceChildren()
+		this.#drum.pause()
+		this.#startButton.textContent = this.#startText
+		this.#bingoNumber.textContent = this.#firstDisplayNumber
+		this.#startButton.focus()
 	}
 }

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -9,18 +9,16 @@ const queryAs = <T extends Element>(selector: string, ctor: abstract new (...arg
 const bingoNumber = queryAs("#bingo-number", HTMLParagraphElement)
 const startButton = queryAs("#start-button", HTMLButtonElement)
 const resetButton = queryAs("#reset-button", HTMLButtonElement)
-const historyTitle = queryAs("#history-title", HTMLParagraphElement)
 const historyDisplay = queryAs("#history-display", HTMLDivElement)
 const drum = queryAs("#drum", HTMLAudioElement)
 const cymbals = queryAs("#cymbals", HTMLAudioElement)
 const resetDialog = queryAs("#reset-confirm", HTMLDialogElement)
 
-if (bingoNumber && startButton && resetButton && historyTitle && historyDisplay && drum && cymbals && resetDialog) {
+if (bingoNumber && startButton && resetButton && historyDisplay && drum && cymbals && resetDialog) {
 	// 可変な設定値を引数として渡す
-	const doms = new DomManipulation(bingoNumber, startButton, resetButton, historyTitle, historyDisplay, "col-2", drum, cymbals, resetDialog, 150)
+	const doms = new DomManipulation(bingoNumber, startButton, historyDisplay, "col-2", drum, cymbals, resetDialog, 150)
 
 	// main
-	startButton.focus()
 	startButton.addEventListener("click", async (): Promise<void> => {
 		try {
 			await doms.rouletteButtonAction()

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,28 +1,40 @@
 import DomManipulation from "./domManipulation.js"
 
-// DOM
-const bingoNumber = document.querySelector("#bingo-number")
-const startButton = document.querySelector("#start-button")
-const resetButton = document.querySelector("#reset-button")
-const historyTitle = document.querySelector("#history-title")
-const historyDisplay = document.querySelector("#history-display")
-const drum = document.querySelector("#drum")
-const cymbals = document.querySelector("#cymbals")
+const queryAs = <T extends Element>(selector: string, ctor: abstract new (...args: never[]) => T): T | null => {
+	const el = document.querySelector(selector)
+	return el instanceof ctor ? el : null
+}
 
-if (bingoNumber instanceof HTMLParagraphElement && startButton instanceof HTMLButtonElement && resetButton instanceof HTMLButtonElement && historyTitle instanceof HTMLParagraphElement && historyDisplay instanceof HTMLDivElement && drum instanceof HTMLAudioElement && cymbals instanceof HTMLAudioElement) {
+// DOM
+const bingoNumber = queryAs("#bingo-number", HTMLParagraphElement)
+const startButton = queryAs("#start-button", HTMLButtonElement)
+const resetButton = queryAs("#reset-button", HTMLButtonElement)
+const historyTitle = queryAs("#history-title", HTMLParagraphElement)
+const historyDisplay = queryAs("#history-display", HTMLDivElement)
+const drum = queryAs("#drum", HTMLAudioElement)
+const cymbals = queryAs("#cymbals", HTMLAudioElement)
+const resetDialog = queryAs("#reset-confirm", HTMLDialogElement)
+
+if (bingoNumber && startButton && resetButton && historyTitle && historyDisplay && drum && cymbals && resetDialog) {
 	// 可変な設定値を引数として渡す
-	const doms = new DomManipulation(bingoNumber, startButton, resetButton, historyTitle, historyDisplay, "col-2", drum, cymbals, 150)
+	const doms = new DomManipulation(bingoNumber, startButton, resetButton, historyTitle, historyDisplay, "col-2", drum, cymbals, resetDialog, 150)
 
 	// main
 	startButton.focus()
-	startButton.addEventListener("click", (): void => {
+	startButton.addEventListener("click", async (): Promise<void> => {
 		try {
-			doms.rouletteButtonAction()
+			await doms.rouletteButtonAction()
 		} catch (e: unknown) {
 			if (e instanceof Error) console.error(e.name, e.message, e.stack)
 		}
 	})
-	resetButton.addEventListener("click", (): void => doms.resetButtonAction())
+	resetButton.addEventListener("click", async (): Promise<void> => {
+		try {
+			await doms.resetButtonAction()
+		} catch (e: unknown) {
+			if (e instanceof Error) console.error(e.name, e.message, e.stack)
+		}
+	})
 } else {
 	console.error("Check the IDs!")
 }

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -8,7 +8,7 @@ const queryAs = <T extends Element>(selector: string, ctor: abstract new (...arg
 // DOM
 const bingoNumber = queryAs("#bingo-number", HTMLParagraphElement)
 const startButton = queryAs("#start-button", HTMLButtonElement)
-const historyDisplay = queryAs("#history-display", HTMLDivElement)
+const historyDisplay = queryAs("#history-display", HTMLOListElement)
 const drum = queryAs("#drum", HTMLAudioElement)
 const cymbals = queryAs("#cymbals", HTMLAudioElement)
 const resetDialog = queryAs("#reset-confirm", HTMLDialogElement)

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -8,13 +8,12 @@ const queryAs = <T extends Element>(selector: string, ctor: abstract new (...arg
 // DOM
 const bingoNumber = queryAs("#bingo-number", HTMLParagraphElement)
 const startButton = queryAs("#start-button", HTMLButtonElement)
-const resetButton = queryAs("#reset-button", HTMLButtonElement)
 const historyDisplay = queryAs("#history-display", HTMLDivElement)
 const drum = queryAs("#drum", HTMLAudioElement)
 const cymbals = queryAs("#cymbals", HTMLAudioElement)
 const resetDialog = queryAs("#reset-confirm", HTMLDialogElement)
 
-if (bingoNumber && startButton && resetButton && historyDisplay && drum && cymbals && resetDialog) {
+if (bingoNumber && startButton && historyDisplay && drum && cymbals && resetDialog) {
 	// 可変な設定値を引数として渡す
 	const doms = new DomManipulation(bingoNumber, startButton, historyDisplay, "col-2", drum, cymbals, resetDialog, 150)
 
@@ -22,13 +21,6 @@ if (bingoNumber && startButton && resetButton && historyDisplay && drum && cymba
 	startButton.addEventListener("click", async (): Promise<void> => {
 		try {
 			await doms.rouletteButtonAction()
-		} catch (e: unknown) {
-			if (e instanceof Error) console.error(e.name, e.message, e.stack)
-		}
-	})
-	resetButton.addEventListener("click", async (): Promise<void> => {
-		try {
-			await doms.resetButtonAction()
 		} catch (e: unknown) {
 			if (e instanceof Error) console.error(e.name, e.message, e.stack)
 		}

--- a/src/ts/numberList.ts
+++ b/src/ts/numberList.ts
@@ -3,11 +3,7 @@ export default class NumberList {
 	readonly #historyListKey = "historyNumberList"
 	readonly #minBingoNumber = 1
 	readonly #maxBingoNumber = 75
-	readonly #allNumberList: number[] = []
-
-	constructor() {
-		for (let i = this.#minBingoNumber; i <= this.#maxBingoNumber; i++) this.#allNumberList.push(i)
-	}
+	readonly #allNumberList: readonly number[] = Array.from({length: this.#maxBingoNumber - this.#minBingoNumber + 1}, (_, i) => i + this.#minBingoNumber)
 
 	get remainList(): number[] {
 		return this.#getListFromLocalStorage(this.#remainListKey)
@@ -25,16 +21,14 @@ export default class NumberList {
 		this.#setListOnLocalStorage(this.#historyListKey, historiesList)
 	}
 
+	#isBingoNumber = (v: unknown): v is number => typeof v === "number" && v >= this.#minBingoNumber && v <= this.#maxBingoNumber
+
 	#getListFromLocalStorage(key: string): number[] {
 		let ret: number[] = []
 		try {
-			ret = JSON.parse(localStorage.getItem(key) || "null")
-			// 初めてのブラウザで開く場合を想定。localStorage にはkey自体が存在しないため、null対応する。
+			ret = JSON.parse(localStorage.getItem(key) ?? "null")
 			if (!Array.isArray(ret)) return []
-			for (const i of ret) {
-				if (typeof i !== "number") throw new Error("The array contains non-digit character in the localStorage!")
-				if (i < this.#minBingoNumber || i > this.#maxBingoNumber) throw new Error("Index out of bounds, not a Bingo number!")
-			}
+			if (!ret.every(this.#isBingoNumber)) throw new Error("The array contains invalid Bingo numbers in the localStorage!")
 		} catch (e: unknown) {
 			if (e instanceof Error) throw new Error(e.message, {cause: e})
 		}
@@ -43,12 +37,16 @@ export default class NumberList {
 
 	#setListOnLocalStorage = (key: string, list: number[]): void => localStorage.setItem(key, JSON.stringify(list))
 
-	generateRandomNumber = (n: number): number => Math.floor(Math.random() * n)
+	generateRandomNumber = (n: number): number => {
+		const buf = new Uint32Array(1)
+		crypto.getRandomValues(buf)
+		return Math.floor(((buf[0] ?? 0) / 2 ** 32) * n)
+	}
 
 	resetLists(): void {
 		localStorage.removeItem(this.#historyListKey)
 		localStorage.removeItem(this.#remainListKey)
-		this.remainList = this.#allNumberList
+		this.remainList = [...this.#allNumberList]
 		this.historyList = []
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,10 +16,6 @@
 		"resolveJsonModule": true,
 		"experimentalDecorators": true
 	},
-	"include": [
-		"src/ts/*"
-	],
-	"exclude": [
-		"node_modules"
-	]
+	"include": ["src/ts/*"],
+	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 概要

TypeScript 6 / 最新 HTML で利用可能な記法へ `src/ts/*.ts` と `src/index.html` を網羅的に刷新する。挙動は等価に保ちつつ、XSS 耐性・a11y・読みやすさ・将来性を改善する。

## 変更内容

### `src/ts/numberList.ts`
- `for` ループ初期化 → `Array.from({length})` + `readonly number[]` 化
- `localStorage.getItem(key) || "null"` → `?? "null"` で空文字誤判定を防止
- 型検証 `for...of` → `.every()` + 推論型述語ヘルパ `#isBingoNumber` (TS 5.5+)
- `Math.random()` → `crypto.getRandomValues()` で偏りのない乱数生成

### `src/ts/domManipulation.ts`
- 全 `innerHTML = "プレーン文字列"` 代入 → `textContent` (XSS 耐性 & 軽量)
- `innerHTML = ""` → `replaceChildren()` (HTML パース不要)
- `appendChild()` → `append()` (近代 DOM API)
- `confirm()` ブロッキング呼び出し → `<dialog>` 要素 + `showModal()` + `close` イベント
- `setTimeout` 再帰ループ → `async/await` + `while` ループに置換し、`try/catch` を実機能化(従来は非同期エラーを捕捉できていなかった)
- コンストラクタが `HTMLDialogElement` を受け取るよう拡張

### `src/ts/index.ts`
- `instanceof` チェーン → `queryAs<T>(selector, ctor)` ヘルパで集約。各 querySelector が `T | null` を返すため、最終 `if` は単純な null 判定のみに収束
- クリックハンドラを `async` 化して `rouletteButtonAction` / `resetButtonAction` の Promise を `await`+try/catch で適切に捕捉

### `src/index.html`
- `<!DOCTYPE html>` → `<!doctype html>` (Prettier 整形)
- `<head prefix="og:http://ogp.me/ns#">` → 削除 (RDFa 旧パターン)
- `<meta http-equiv="X-UA-Compatible">` → 削除 (IE EOL 済)
- `viewport` の `minimum-scale=1.0` → 削除 (a11y 配慮、ピンチズーム許可)
- `<script type="module" defer>` の `defer` → 削除 (ES Modules はデフォルトで deferred)
- `<noscript>` 内 iframe の `style="display:none; visibility:hidden"` → `hidden` 属性
- `preconnect` の `crossorigin` → `crossorigin="anonymous"` 明示
- リセット確認用 `<dialog id="reset-confirm">` + form `method="dialog"` を追加

## 動作確認

Chrome (DevTools 経由) で以下の経路を実機検証:

- [x] 初期描画 (bingoNumber=`00`, ボタン文言, history 表示)
- [x] START 押下 → ルーレット動作 (数字が高速に切り替わる)
- [x] STOP 押下 → 数字確定 (履歴に追加、localStorage 反映)
- [x] RESET 押下 → `<dialog>` モーダルが開く
- [x] OK 選択 → 状態リセット (bingoNumber=`00`, 履歴クリア, START にフォーカス)
- [x] Cancel 選択 → 状態保持 (リセットされない)
- [x] コンソールエラー無し
- [x] `pnpm run build` (TypeScript 6.0.3) 成功
- [x] `pnpm exec eslint src/ts/` パス
- [x] `pnpm exec prettier --check` パス

## 適用しなかった項目(別 PR / 別タスク向け)

事前列挙のうち、以下は機能変更や別軸の意思決定を含むため本 PR では見送り。

- Bootstrap 5.0.2 → 5.3.x: SRI ハッシュ更新 & 視覚回帰テストが必要
- GTM Consent Mode v2: デフォルト同意状態の業務判断が必要
- `<audio preload="auto">` → `"metadata"`: 初回クリックの即応性に影響しうる UX 判断
- PWA / `apple-touch-icon` 追加: 機能追加
- アローメソッド → `@bound` Stage 3 デコレータ: デコレータ導入の是非を要検討
- `accessor` キーワード: Stage 3 デコレータ未導入下では効果薄
- `NumberList` getter/setter の localStorage 都度シリアライズ: 構造的リファクタ