### PR TITLE
ci: npm dependabot PRでCIを確実にスキップするラベルベース判定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+      - "skip-ci"
     open-pull-requests-limit: 10
     pull-request-branch-name:
       separator: "_"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,6 +6,7 @@ on:
       - main
 jobs:
   Dependency-Review:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
@@ -17,6 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/dependency-review-action@v5
   Build-Check:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## 期待する挙動・状態

- npm dependabot のPR (タイトル先頭 `[skip ci]`) で `Dependency Check` workflow を確実にスキップ
- github-actions dependabot のPR (タイトル先頭 `check ci status`) は従来通り CI 実行

## 必要な依存関係

- なし(ワークフロー設定のみ)

## 確認済み項目

- [x] `actionlint` でワークフロー構文を検証
- [x] 過去 PR #357 / #351 の workflow runs を確認し、 `Deploy pages` (push: main) は GitHub の自動 `[skip ci]` で既に正常スキップ済みであることを確認
- [x] `main` ブランチに branch protection が無いため、 `skip-ci` ラベルでジョブが skipped 状態になっても auto-merge に影響しないことを確認

## 見てほしいところ

- [ ] PRのLabelsの設定は適切か
- [ ] ラベル `skip-ci` を skip 判定のキーにする設計でよいか(代替案: `dependencies` ラベルや actor 判定など)
- [ ] `Dependency Review` は npm 依存の脆弱性スキャンが目的だが、 npm dependabot PR で skip するトレードオフを許容するか

## 背景

GitHub Actions の `[skip ci]` は `push` および `pull_request` イベントで動作するとされているが、 公式ドキュメントは **どの pull_request types で効くか** を明示していない。 特にコミット push を伴わない `review_requested` / `ready_for_review` / `reopened` などの特殊 types ではコミュニティで挙動が不安定と報告されている。

このリポジトリの `dependency-review.yml` は trigger types を `[review_requested, reopened, ready_for_review]` に限定しており、 該当 types で何らかの操作(手動レビュアー指定など)が発生した場合に `[skip ci]` が効かない可能性がある。

## 変更内容

| ファイル | 変更 |
|---|---|
| `.github/dependabot.yml` | npm エコシステムの `labels` に `skip-ci` を追加 |
| `.github/workflows/dependency-review.yml` | `Dependency-Review` / `Build-Check` 各ジョブに `if: !contains(github.event.pull_request.labels.*.name, 'skip-ci')` を追加 |

## 検証で判明した既存挙動

- **`Deploy pages` (push: main)** : npm `[skip ci]` PR のマージコミットに対する workflow runs を確認したところ実行されていない → GitHub の自動 `[skip ci]` で **既に正常スキップ済み**(本PRでは触らない)
- **`Dependency Check` (pull_request)** : 過去 30 件の workflow runs において npm dependabot PR で起動した形跡なし(trigger types が `opened` を含まないため通常は発火しない)

つまり今回の修正は観測された不具合への直接修正ではなく **defense-in-depth** の保険。

## 関連

- 外部ツール (CodeQL / DeepScan / Snyk) は GitHub Actions の `[skip ci]` の管轄外。 これらを止めたい場合は各サービス側の設定が必要。