### PR TITLE
launch.jsonをWSL→Windowsブラウザ構成に切り替え

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 src/js/*
 .vscode/settings.json
+.vscode/chrome-debug-profile/
+.vscode/edge-debug-profile/
 .idea/*
 .DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,33 +6,12 @@
 			"request": "launch",
 			"type": "chrome",
 			"url": "http://localhost:62800/src/index.html",
-			"webRoot": "${workspaceFolder}"
-		},
-		{
-			"name": "Launch Firefox",
-			"request": "launch",
-			"type": "firefox",
-			"reAttach": true,
-			"url": "http://localhost:62800/src/index.html"
-		},
-		{
-			"name": "Launch Edge",
-			"request": "launch",
-			"type": "msedge",
-			"url": "http://localhost:62800/src/index.html",
-			"webRoot": "${workspaceFolder}"
-		},
-		{
-			"name": "Launch Chrome (WSL → Windows)",
-			"request": "launch",
-			"type": "chrome",
-			"url": "http://localhost:62800/src/index.html",
 			"webRoot": "${workspaceFolder}",
 			"runtimeExecutable": "/mnt/c/Program Files/Google/Chrome/Application/chrome.exe",
 			"userDataDir": "${workspaceFolder}/.vscode/chrome-debug-profile"
 		},
 		{
-			"name": "Launch Edge (WSL → Windows)",
+			"name": "Launch Edge",
 			"request": "launch",
 			"type": "msedge",
 			"url": "http://localhost:62800/src/index.html",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,24 @@
 			"type": "msedge",
 			"url": "http://localhost:62800/src/index.html",
 			"webRoot": "${workspaceFolder}"
+		},
+		{
+			"name": "Launch Chrome (WSL → Windows)",
+			"request": "launch",
+			"type": "chrome",
+			"url": "http://localhost:62800/src/index.html",
+			"webRoot": "${workspaceFolder}",
+			"runtimeExecutable": "/mnt/c/Program Files/Google/Chrome/Application/chrome.exe",
+			"userDataDir": "${workspaceFolder}/.vscode/chrome-debug-profile"
+		},
+		{
+			"name": "Launch Edge (WSL → Windows)",
+			"request": "launch",
+			"type": "msedge",
+			"url": "http://localhost:62800/src/index.html",
+			"webRoot": "${workspaceFolder}",
+			"runtimeExecutable": "/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe",
+			"userDataDir": "${workspaceFolder}/.vscode/edge-debug-profile"
 		}
 	]
 }


### PR DESCRIPTION
## 概要

WSL2 環境で VS Code を動かし、Windows 側ブラウザでアプリを閲覧・デバッグするための launch 構成に切り替えます。ホストマシン直接実行を前提とした既存エントリは削除し、WSL→Windows 構成に統一します。

## 変更内容

- \`.vscode/launch.json\`:
  - 既存 3 エントリ（Launch Chrome / Launch Firefox / Launch Edge）を削除
  - WSL から Windows 側 Chrome / Edge を起動する 2 エントリに置き換え
- \`.gitignore\`: \`userDataDir\` 用デバッグプロファイルを除外

## 設計判断

- **WSL 構成に統一**: ホストマシン用は使われない前提で削除し、エントリ数を抑える
- **\`runtimeExecutable\` 指定**: WSL2 の localhost forwarding が効くため \`url\` は変更不要、Windows バイナリパス（\`/mnt/c/...\`）のみ指定
- **\`userDataDir\` の分離**: workspace 配下のディレクトリに分けることで、普段使いの Chrome/Edge セッションとの衝突（\`Chrome is already running\` 系エラー）を回避
- **Firefox は未追加**: 現状 Windows 側に未インストール

## 動作確認の前提

- WSL2 上で \`pnpm run serve\` を起動済みであること
- Windows 側に Chrome / Edge がデフォルトパスにインストール済みであること

## 補足

ソースマップ越しにブレークポイントを使う場合は \`sourceMapPathOverrides\` の追加が必要な場合あり。今回は閲覧用途のため未追加。