### PR TITLE
ci(dependabot): npm の [skip ci] prefix を削除し全てのCIを実行する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
     directory: "/"
     allow:
       - dependency-type: "production"
-    commit-message:
-      prefix: "[skip ci]"
-      include: "scope"
     labels:
       - "dependencies"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## 期待する挙動・状態

- npm dependabot のPR でも、 すべての CI / 外部ツールを通常通り実行する
- コミットメッセージは dependabot デフォルト (例: \`Bump xxx from 1.0.0 to 1.1.0\`)

## 必要な依存関係

- なし

## 確認済み項目

- [x] github-actions エコシステムの \`check ci status\` プレフィックスは維持 (CI実行の意図のため)
- [x] \`labels: [\"dependencies\"]\` は維持 (両エコシステム共通)
- [x] PR #369 (label-based skip-ci 判定) は破棄済み

## 見てほしいところ

- [ ] PRのLabelsの設定は適切か
- [ ] github-actions の \`check ci status\` プレフィックスも統一(削除)するか、 現状維持か
- [ ] dependabot がデフォルトのコミットメッセージで動作することを次回 dependabot 起動時 (npm: daily 10:00 JST) に確認

## 背景

`[skip ci]` プレフィックスでCIをスキップする方針から、 **dependabot のPRでもCIを全て走らせる** 方針に転換。 理由:

- GitHub Actions の `[skip ci]` は `pull_request` の特殊 types (`review_requested` / `ready_for_review` / `reopened`) における挙動が公式に明示されておらず信頼性に欠ける
- 外部ツール (CodeQL / DeepScan / Snyk) は GitHub Actions の管轄外で `[skip ci]` の影響を受けない
- 部分的にしかスキップできないなら、 一貫してすべて実行する方が混乱がない

## 変更内容

| ファイル | 変更 |
|---|---|
| `.github/dependabot.yml` | npm エコシステムの `commit-message` セクション (prefix `[skip ci]` + include scope) を削除 |

github-actions エコシステムは既存のコミット履歴 (`check ci status(deps): bump ...`) との連続性のため変更なし。