### PR TITLE
Claude Code のローカル作業ディレクトリ .claude/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ src/js/*
 .vscode/chrome-debug-profile/
 .vscode/edge-debug-profile/
 .idea/*
+.claude/
 .DS_Store
 
 # APM の依存関係
@@ -15,5 +16,4 @@ apm.lock.yaml
 # APM コンパイル成果物 (.apm/ から `apm install` / `apm compile` で再生成されるため追跡しない)
 AGENTS.md
 CLAUDE.md
-.claude/rules/
 .github/instructions/


### PR DESCRIPTION
## 期待する挙動・状態

- `git status` で `?? .claude/` が untracked として出現しなくなる
- Claude Code が `.claude/worktrees/` 配下に作成するローカル worktree や設定が誤って commit/push されるリスクが消える
- ユーザー影響なし（ランタイム・ビルド成果物には変化なし）

## 背景

ルート直下を精査した結果、`.claude/` のみ `.gitignore` 未登録で毎回 untracked として表示されていた。`.remember/` は内部に `.gitignore` (`*`) で自己除外済みだが、`.claude/` は何も無く、誤コミット導線になっていた。

## 必要な依存関係

- なし

## 確認済み項目

- [x] 変更後の `git status` がクリーンになる
- [x] `.gitignore` の論理グループ（IDE/エディタ設定）に沿った位置 (`.idea/*` の直後) に挿入
- [x] パターンは末尾 `/` 付きでディレクトリ限定

## 見てほしいところ

- 挿入位置とパターン (`.claude/`) の妥当性