### PR TITLE
APM 管理対象として MCP サーバー 4 つと Claude Code プラグイン 2 つを追加

### DIFF
--- a/.apm/instructions/apm-plugins.instructions.md
+++ b/.apm/instructions/apm-plugins.instructions.md
@@ -1,0 +1,79 @@
+---
+description: APM (Agent Project Manager) を介した Claude Code プラグインの運用ルール
+applyTo: "apm.yml"
+---
+
+# APM プラグイン管理ルール
+
+## Source of Truth
+
+`apm.yml` の `dependencies.apm` がこのリポジトリで使う Claude Code プラグイン (Skills / commands / prompts / hooks 等のバンドル) の Source of Truth。
+`apm install` を実行すると、ここに宣言されたプラグインが `apm_modules/` にダウンロードされ、各成果物 (`.claude/skills/`, `.claude/commands/`, `.agents/skills/`, `.github/prompts/` 等) に展開される。
+
+## 配信されるプラグイン
+
+| プラグイン | リポジトリ | 用途 |
+| --- | --- | --- |
+| `code-review` | [anthropics/claude-code](https://github.com/anthropics/claude-code) (path: `plugins/code-review`) | PR の自動コードレビュー (複数の専門エージェントが confidence ベースで採点) |
+| `superpowers` | [obra/superpowers](https://github.com/obra/superpowers) | TDD・デバッグ・コラボレーションの汎用スキル群 (brainstorming, systematic-debugging, writing-plans 等 14 スキル) |
+
+## SHA ピン
+
+`dependencies.apm` のエントリは **必ず `#<sha>` でピンする**。`apm install` で `unpinned -- add #tag or #sha to prevent drift` という警告が出るため気付ける。
+
+```yaml
+dependencies:
+  apm:
+  - anthropics/claude-code/plugins/code-review#39e853e4074d90f27afdfb7ea601e0fc378bd0c5
+  - obra/superpowers#f2cbfbefebbfef77321e4c9abc9e949826bea9d7
+```
+
+理由: ピンしないと `apm install` 毎に上流の `main` を引いてしまい、各メンバーの開発体験が静かにドリフトする ([[apm_workflow]] のドリフト防止方針)。
+
+## プラグインの追加
+
+### marketplace 経由 (推奨。検索用)
+
+```bash
+# 1. marketplace を一時的に register (global config のみ。apm.yml には影響しない)
+apm marketplace add <owner>/<repo>
+# 2. plugin を install (apm.yml に追記される)
+apm install <plugin>@<marketplace-name>
+# 3. unpinned 警告が出るので apm.lock.yaml の resolved_commit を見て #sha でピン
+```
+
+### 直接 GitHub から (marketplace 未登録のプラグイン)
+
+```bash
+apm install <owner>/<repo>#<sha>
+# または path 指定
+apm install <owner>/<repo>/<path>#<sha>
+```
+
+`apm.yml` に `<owner>/<repo>[/<path>]#<sha>` 形式が直接書ければ、global の marketplace 登録は **不要**。
+チームメイトは `git clone` 後 `apm install` だけで同じプラグインを取得できる。
+
+## プラグインの削除
+
+`apm.yml` の `dependencies.apm` 配下から該当行を削除した後、`apm install` を再実行する。
+`apm_modules/<owner>/<repo>/` と展開済みファイルが残った場合は手動で掃除する。
+(`apm uninstall <package>` の動作は本リポジトリでは未検証)
+
+## 生成物の場所
+
+`apm install` がプラグインを展開する先。すべて `.gitignore` 対象。
+
+| パス | 由来 |
+| --- | --- |
+| `apm_modules/<owner>/<repo>/` | プラグインのソースコピー (cache) |
+| `.claude/skills/` | Claude Code Skills (SKILL.md) |
+| `.agents/skills/` | クロスクライアント Skills (Cursor / Codex / Gemini 等が読む) |
+| `.claude/commands/` | Claude Code スラッシュコマンド |
+| `.claude/hooks/` | Claude Code フックスクリプト |
+| `.claude/apm-hooks.json` | APM がフック登録に用いる索引 |
+| `.claude/settings.json` | フック有効化等のクライアント設定 |
+| `.github/prompts/` | GitHub Copilot プロンプト |
+| `.github/hooks/` | GitHub 用フック (Copilot CLI 等) |
+
+`.claude/settings.json` を ignore しているのは、APM がプラグインのフック有効化のために絶対パスを書き込むため (リポジトリで共有しても各環境でパスが食い違って意味がない)。
+個人の Claude Code 設定はユーザースコープ (`~/.claude/settings.json`) または `.claude/settings.local.json` (Claude Code の慣習で per-user 扱い) に置くこと。

--- a/.apm/instructions/apm-workflow.instructions.md
+++ b/.apm/instructions/apm-workflow.instructions.md
@@ -14,23 +14,29 @@ applyTo: ".apm/**"
 
 | パス | 役割 | リポジトリ追跡 |
 | --- | --- | --- |
-| `.apm/instructions/*.instructions.md` | **Source of Truth (人間が編集する)** | ✅ 追跡する |
+| `.apm/instructions/*.instructions.md` | **Source of Truth (instructions 用、人間が編集する)** | ✅ 追跡する |
+| `apm.yml` の `dependencies.mcp` | **Source of Truth (MCP サーバー用、人間が編集する)** | ✅ 追跡する |
 | `.github/copilot-instructions.md` | Copilot Code Review に SoT への参照を伝えるスタブ | ✅ 追跡する |
 | `.github/instructions/*.instructions.md` | `apm install` で生成 (Copilot 新形式) | ❌ 追跡しない |
 | `.claude/rules/*.md` | `apm install` で生成 (Claude Code 補助) | ❌ 追跡しない |
 | `CLAUDE.md` / `AGENTS.md` (各所) | `apm compile` で生成 | ❌ 追跡しない |
 | `apm.lock.yaml` | `apm install` で生成 | ❌ 追跡しない |
+| `.mcp.json` | `apm install` で生成 (Claude Code MCP 設定) | ❌ 追跡しない |
+| `.vscode/mcp.json` | `apm install` で生成 (GitHub Copilot in VS Code MCP 設定) | ❌ 追跡しない |
+| `.codex/config.toml` | `apm install` で生成 (Codex CLI MCP 設定) | ❌ 追跡しない |
 
 ## ローカルでの作業
 
-`.apm/instructions/` を編集後、ローカルで以下を実行することで生成物が更新される (任意)。
+`.apm/instructions/` または `apm.yml` を編集後、ローカルで以下を実行することで生成物が更新される (任意)。
 
 ```bash
-apm install   # .github/instructions/ と .claude/rules/ を更新
+apm install   # 全プリミティブを再デプロイ (.github/instructions/, .claude/rules/, .mcp.json, .vscode/mcp.json, .codex/config.toml)
 apm compile   # CLAUDE.md / AGENTS.md を更新
 ```
 
 ただし、生成物はすべて `.gitignore` 対象のためコミットには含まれない。
+
+MCP サーバーの追加・運用手順は [`mcp-servers.instructions.md`](./mcp-servers.instructions.md) を参照。
 
 ## GitHub Copilot Code Review への指示伝達
 

--- a/.apm/instructions/apm-workflow.instructions.md
+++ b/.apm/instructions/apm-workflow.instructions.md
@@ -16,6 +16,7 @@ applyTo: ".apm/**"
 | --- | --- | --- |
 | `.apm/instructions/*.instructions.md` | **Source of Truth (instructions 用、人間が編集する)** | ✅ 追跡する |
 | `apm.yml` の `dependencies.mcp` | **Source of Truth (MCP サーバー用、人間が編集する)** | ✅ 追跡する |
+| `apm.yml` の `dependencies.apm` | **Source of Truth (Claude Code プラグイン用、人間が編集する)** | ✅ 追跡する |
 | `.github/copilot-instructions.md` | Copilot Code Review に SoT への参照を伝えるスタブ | ✅ 追跡する |
 | `.github/instructions/*.instructions.md` | `apm install` で生成 (Copilot 新形式) | ❌ 追跡しない |
 | `.claude/rules/*.md` | `apm install` で生成 (Claude Code 補助) | ❌ 追跡しない |
@@ -24,6 +25,7 @@ applyTo: ".apm/**"
 | `.mcp.json` | `apm install` で生成 (Claude Code MCP 設定) | ❌ 追跡しない |
 | `.vscode/mcp.json` | `apm install` で生成 (GitHub Copilot in VS Code MCP 設定) | ❌ 追跡しない |
 | `.codex/config.toml` | `apm install` で生成 (Codex CLI MCP 設定) | ❌ 追跡しない |
+| `apm_modules/`, `.agents/skills/`, `.claude/skills/`, `.claude/commands/`, `.claude/hooks/`, `.claude/settings.json`, `.claude/apm-hooks.json`, `.github/prompts/`, `.github/hooks/` | `apm install` で生成 (APM プラグイン展開先) | ❌ 追跡しない |
 
 ## ローカルでの作業
 
@@ -37,6 +39,7 @@ apm compile   # CLAUDE.md / AGENTS.md を更新
 ただし、生成物はすべて `.gitignore` 対象のためコミットには含まれない。
 
 MCP サーバーの追加・運用手順は [`mcp-servers.instructions.md`](./mcp-servers.instructions.md) を参照。
+APM プラグイン (Skills / commands 等) の追加・運用手順は [`apm-plugins.instructions.md`](./apm-plugins.instructions.md) を参照。
 
 ## GitHub Copilot Code Review への指示伝達
 

--- a/.apm/instructions/mcp-servers.instructions.md
+++ b/.apm/instructions/mcp-servers.instructions.md
@@ -55,8 +55,11 @@ APM 公式レジストリ (`apm mcp search` / `apm mcp install <registry-name>`)
 | `.vscode/mcp.json` | GitHub Copilot in VS Code |
 | `.codex/config.toml` | Codex CLI |
 
-## APM の `--skill` プリミティブとの違い
+## APM の他のプリミティブとの違い
 
-APM には `--skill` フラグで扱う SKILL.md バンドル (Claude Code Skills) という別プリミティブが存在する。
-このリポジトリで管理しているのは **MCP サーバー** であり、APM の `--skill` プリミティブとは別概念。
-両者を混同しないこと。
+APM は MCP サーバーのほかに、以下のプリミティブも扱える。
+
+- **APM パッケージ (`dependencies.apm`)**: Skills (SKILL.md バンドル) / commands / prompts / hooks 等を含む Claude Code プラグインを GitHub から取得する。このリポジトリでは `code-review`, `superpowers` を採用 → [`apm-plugins.instructions.md`](./apm-plugins.instructions.md)
+- **APM スキル (`--skill` フラグ)**: SKILL_BUNDLE から個別の SKILL.md を選択的にインストール
+
+MCP サーバー / APM パッケージ / APM スキル はそれぞれ独立したプリミティブなので、用語を混同しないこと。

--- a/.apm/instructions/mcp-servers.instructions.md
+++ b/.apm/instructions/mcp-servers.instructions.md
@@ -1,0 +1,62 @@
+---
+description: APM (Agent Project Manager) を介した MCP サーバーの運用ルール
+applyTo: "apm.yml"
+---
+
+# MCP サーバー管理ルール
+
+## Source of Truth
+
+`apm.yml` の `dependencies.mcp` がこのリポジトリで使う MCP サーバーの Source of Truth。
+`apm install` を実行すると、ここに宣言された MCP サーバーが Claude Code / Codex CLI / GitHub Copilot (in VS Code) の各 IDE 設定に展開される。
+
+## 配信される MCP サーバー
+
+| 名前 | 起動コマンド | 用途 | 必要な前提 |
+| --- | --- | --- | --- |
+| `semgrep` | `uvx semgrep-mcp` | 静的解析 (SAST) によるコード品質・セキュリティ検査 | `uv` |
+| `chrome-devtools` | `npx chrome-devtools-mcp@latest` | Chrome DevTools 経由のブラウザ自動化・パフォーマンス計測 | `node` (Chrome は実行時にダウンロード) |
+| `serena` | `uvx --from git+https://github.com/oraios/serena serena start-mcp-server` | LSP ベースのシンボル指向コード探索・編集 | `uv` |
+| `context7` | `npx -y @upstash/context7-mcp` | ライブラリ公式ドキュメントの最新版を取得 | `node` |
+
+## 開発者の前提条件
+
+上記表の通り、以下のランタイムが PATH にあれば全 MCP サーバーが動作する。
+
+- [uv](https://docs.astral.sh/uv/) (`uvx` を経由して PyPI / git ソースの Python パッケージを実行)
+- [Node.js](https://nodejs.org/) (`npx` 経由)
+
+## サーバーの追加
+
+`apm install --mcp <name> -- <command> [args...]` で `apm.yml` に追記される。
+
+```bash
+# 例: 新しい MCP サーバーを追加
+apm install --mcp my-server -- npx -y @example/my-mcp
+```
+
+### APM レジストリは使わないこと
+
+APM 公式レジストリ (`apm mcp search` / `apm mcp install <registry-name>`) は 2026 年 5 月時点で
+解決結果が不正なケースがある (例: `oraios/serena` が `uvx ide-assistant` という別物に展開される)。
+このリポジトリでは **すべて self-defined (`-- <command> [args...]` 指定)** で登録する。
+
+## サーバーの削除
+
+`apm.yml` の `dependencies.mcp` 配下から該当エントリを手で削除した後、`apm install` を再実行する。
+
+## 生成物の場所
+
+`apm install` が以下のファイルを生成する。すべて `.gitignore` 対象。
+
+| パス | 対応 IDE |
+| --- | --- |
+| `.mcp.json` | Claude Code (project scope) |
+| `.vscode/mcp.json` | GitHub Copilot in VS Code |
+| `.codex/config.toml` | Codex CLI |
+
+## APM の `--skill` プリミティブとの違い
+
+APM には `--skill` フラグで扱う SKILL.md バンドル (Claude Code Skills) という別プリミティブが存在する。
+このリポジトリで管理しているのは **MCP サーバー** であり、APM の `--skill` プリミティブとは別概念。
+両者を混同しないこと。

--- a/.apm/instructions/mcp-servers.instructions.md
+++ b/.apm/instructions/mcp-servers.instructions.md
@@ -15,9 +15,24 @@ applyTo: "apm.yml"
 | 名前 | 起動コマンド | 用途 | 必要な前提 |
 | --- | --- | --- | --- |
 | `semgrep` | `uvx semgrep-mcp` | 静的解析 (SAST) によるコード品質・セキュリティ検査 | `uv` |
-| `chrome-devtools` | `npx chrome-devtools-mcp@latest` | Chrome DevTools 経由のブラウザ自動化・パフォーマンス計測 | `node` (Chrome は実行時にダウンロード) |
-| `serena` | `uvx --from git+https://github.com/oraios/serena serena start-mcp-server` | LSP ベースのシンボル指向コード探索・編集 | `uv` |
+| `chrome-devtools` | `npx -y chrome-devtools-mcp@1.0.1` | Chrome DevTools 経由のブラウザ自動化・パフォーマンス計測 | `node` (Chrome は実行時にダウンロード) |
+| `serena` | `uvx --from git+https://github.com/oraios/serena@c3a8d5a9c5 serena start-mcp-server` | LSP ベースのシンボル指向コード探索・編集 | `uv` |
 | `context7` | `npx -y @upstash/context7-mcp` | ライブラリ公式ドキュメントの最新版を取得 | `node` |
+
+## バージョン固定方針
+
+再現性確保のため、`@latest` や git ブランチ HEAD ではなく **具体バージョン or コミット SHA でピン** する ([[apm_workflow]] のドリフト防止方針)。
+
+- npm 系: `<package>@<semver>` (例: `chrome-devtools-mcp@1.0.1`)
+- git 系: `git+<url>@<sha>` (例: `git+https://github.com/oraios/serena@c3a8d5a9...`)
+- 例外: `semgrep-mcp` / `@upstash/context7-mcp` は API が安定しているため固定省略 (将来必要に応じて固定)
+
+更新するときは PR でレビュー可能な形に。`npm view <package> dist-tags` と `git ls-remote --tags <url>` で最新を確認。
+
+## npx の非対話起動
+
+`npx` は未インストールパッケージを実行する際に確認プロンプトを表示するため、`-y` (auto-yes) を必ず付ける。
+これがないと CI など非対話環境でハング・失敗する可能性がある。
 
 ## 開発者の前提条件
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,13 @@ CLAUDE.md
 .codex/
 .vscode/mcp.json
 .mcp.json
+
+# APM プラグイン (skills / commands / prompts / hooks / settings) の展開先 (apm.yml の dependencies.apm から `apm install` で再生成されるため追跡しない)
+.agents/skills/
+.claude/commands/
+.claude/skills/
+.claude/hooks/
+.claude/apm-hooks.json
+.claude/settings.json
+.github/prompts/
+.github/hooks/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ AGENTS.md
 CLAUDE.md
 .claude/rules/
 .github/instructions/
+
+# APM MCP 設定生成物 (apm.yml の dependencies.mcp から `apm install` で再生成されるため追跡しない)
+.codex/
+.vscode/mcp.json
+.mcp.json

--- a/apm.yml
+++ b/apm.yml
@@ -22,14 +22,15 @@ dependencies:
     transport: stdio
     command: npx
     args:
-    - chrome-devtools-mcp@latest
+    - -y
+    - chrome-devtools-mcp@1.0.1
   - name: serena
     registry: false
     transport: stdio
     command: uvx
     args:
     - --from
-    - git+https://github.com/oraios/serena
+    - git+https://github.com/oraios/serena@c3a8d5a9c54622c8ce771a54e5feffd6efda8749
     - serena
     - start-mcp-server
   - name: context7

--- a/apm.yml
+++ b/apm.yml
@@ -1,19 +1,41 @@
-# APM (Agent Project Manager) マニフェスト
-# 参考: https://github.com/microsoft/apm
 name: bingo-machine
 version: 1.6.5
 description: AI agent instructions for the Bingo Machine project
 author: ROhta
 license: GPL-3.0-or-later
-
-# 単一目的: このパッケージは instructions プリミティブのみを配信する
 type: instructions
-
-# コンパイル対象: Claude Code, Codex CLI, GitHub Copilot
-target:
-  - claude
-  - codex
-  - copilot
-
-# .apm/ 配下のすべてのプリミティブを自動公開
+targets:
+- claude
+- codex
+- copilot
 includes: auto
+dependencies:
+  mcp:
+  - name: semgrep
+    registry: false
+    transport: stdio
+    command: uvx
+    args:
+    - semgrep-mcp
+  - name: chrome-devtools
+    registry: false
+    transport: stdio
+    command: npx
+    args:
+    - chrome-devtools-mcp@latest
+  - name: serena
+    registry: false
+    transport: stdio
+    command: uvx
+    args:
+    - --from
+    - git+https://github.com/oraios/serena
+    - serena
+    - start-mcp-server
+  - name: context7
+    registry: false
+    transport: stdio
+    command: npx
+    args:
+    - -y
+    - '@upstash/context7-mcp'

--- a/apm.yml
+++ b/apm.yml
@@ -39,3 +39,6 @@ dependencies:
     args:
     - -y
     - '@upstash/context7-mcp'
+  apm:
+  - anthropics/claude-code/plugins/code-review#39e853e4074d90f27afdfb7ea601e0fc378bd0c5
+  - obra/superpowers#f2cbfbefebbfef77321e4c9abc9e949826bea9d7


### PR DESCRIPTION
## Summary

`apm.yml` の `dependencies` を Source of Truth として、以下 2 種類のプリミティブを APM 管理下に追加。

### `dependencies.mcp` (MCP サーバー 4 つ、self-defined・バージョン固定)

| 名前 | 起動コマンド | 用途 |
| --- | --- | --- |
| `semgrep` | `uvx semgrep-mcp` | 静的解析 (SAST) |
| `chrome-devtools` | `npx -y chrome-devtools-mcp@1.0.1` | Chrome DevTools 経由のブラウザ自動化 |
| `serena` | `uvx --from git+https://github.com/oraios/serena@c3a8d5a9c5 serena start-mcp-server` | LSP ベースのコード探索 |
| `context7` | `npx -y @upstash/context7-mcp` | ライブラリ公式ドキュメント取得 |

### `dependencies.apm` (Claude Code プラグイン 2 つ、SHA pin 済み)

| プラグイン | リポジトリ | 用途 |
| --- | --- | --- |
| `code-review` | [anthropics/claude-code](https://github.com/anthropics/claude-code) `plugins/code-review` | PR の自動コードレビュー |
| `superpowers` | [obra/superpowers](https://github.com/obra/superpowers) | TDD・デバッグ・コラボの汎用 Skill 群 (14 スキル) |

`apm install` 一発で Claude Code (`.mcp.json` + `.claude/skills/` + `.claude/commands/` + `.claude/hooks/`) / GitHub Copilot in VS Code (`.vscode/mcp.json` + `.github/prompts/`) / Codex CLI (`.codex/config.toml`) の全 IDE 設定が再現される。

## ドリフト防止策

- 生成物 (`.mcp.json`, `.vscode/mcp.json`, `.codex/config.toml`, `.agents/skills/`, `.claude/skills/`, `.claude/commands/`, `.claude/hooks/`, `.claude/settings.json`, `.claude/apm-hooks.json`, `.github/prompts/`, `.github/hooks/`, `apm_modules/`) はすべて `.gitignore` 対象
- **Source of Truth は `apm.yml` のみ** という既存方針 ([PR #366](https://github.com/ROhta/bingo/pull/366)) を MCP / APM プリミティブにも拡張
- `dependencies.apm` の各エントリは `#<sha>` で必ずピン (`apm install` の `unpinned -- add #tag or #sha to prevent drift` 警告に従う)
- `dependencies.mcp` でも **再現性確保のため `@<version>` または `@<sha>` で固定** (Copilot Review #2 #3 を反映)
- `npx` 起動時は `-y` を必ず付ける (npx の対話プロンプトが CI 等の非対話環境でハングするリスクを排除。Copilot Review #1 を反映)

## なぜ APM レジストリ経由ではなく self-defined / 直接 GitHub にしたか

- **MCP**: APM 公式レジストリ (`apm mcp install <registry-name>`) の解決結果が不正な場合がある (例: `oraios/serena` が `uvx ide-assistant` という別物に展開される)。`-- <command> [args...]` 形式の self-defined なら各 IDE 設定に意図したコマンドがそのまま展開される
- **プラグイン**: `<owner>/<repo>[/<path>]#<sha>` 形式は GitHub から直接解決されるため、`apm marketplace add` (global config への書き込み) は不要。チームメイトは clone 後 `apm install` するだけで再現可能 (marketplace 未登録環境で検証済み)

## 副次変更: `target:` (単数) → `targets:` (複数) リネーム

APM 0.14.1 の MCP デプロイロジックは `targets:` (複数形) を要求する。`target:` のままだと `apm install --only mcp` が `Unknown target 'vscode'` で失敗するため必要なリネーム。

## semgrep の構成選択

- 公式 Claude Code プラグインは `semgrep mcp` (Semgrep CLI のサブコマンド) を使うが、本 PR では **`uvx semgrep-mcp`** (Semgrep 公式 PyPI 版 [`semgrep/mcp`](https://github.com/semgrep/mcp)) を採用
- 理由: 開発者の前提条件を **`uv` と `node` だけ** に統一。Semgrep CLI の事前インストール不要 (semgrep バイナリも `uvx semgrep-mcp` 初回起動時に自動ダウンロード)

## `.claude/settings.json` を ignore する理由

APM がプラグインのフック有効化のため `.claude/settings.json` に **絶対パス** (`/home/$USER/...`) を書き込む。リポジトリで共有しても各環境でパスが食い違って機能しないため、generated artifact として扱う。
個人の Claude Code 設定は `~/.claude/settings.json` か `.claude/settings.local.json` (Claude Code の慣習で per-user 扱い) に置く。

## 用語の整理 (MCP / APM パッケージ / APM スキル)

APM のプリミティブは 3 種類あり、互いに別概念:

1. **MCP サーバー** (`dependencies.mcp`): IDE に提供するツール群 (今回の semgrep / chrome-devtools / serena / context7)
2. **APM パッケージ** (`dependencies.apm`): Skills / commands / prompts / hooks のバンドル (今回の code-review / superpowers)
3. **APM スキル** (`--skill` フラグ): SKILL_BUNDLE から個別の SKILL.md を選択インストール (本 PR では未使用)

ユーザー要望の「skill として管理」は (1) MCP サーバーと (2) APM パッケージ の混在解釈で、本 PR では両者を APM 管理下にした。`mcp-servers.instructions.md` / `apm-plugins.instructions.md` で各プリミティブを文書化。

## Copilot Code Review 対応 (commit `afb6ac8`)

| # | 指摘 | 対応 |
| - | --- | --- |
| 1 | `chrome-devtools` の npx 起動が対話プロンプトに依存しうる | `args` に `-y` を追加 |
| 2 | `chrome-devtools-mcp@latest` は再現性が落ちる | `chrome-devtools-mcp@1.0.1` にバージョン固定 |
| 3 | `git+https://.../oraios/serena` がブランチ HEAD を引く | `@c3a8d5a9c54622c8ce771a54e5feffd6efda8749` (v1.5.1 相当) で SHA pin |

`mcp-servers.instructions.md` にもバージョン固定方針と `npx -y` 必須化のルールを追記。

## Smoke test

- `uvx semgrep-mcp --help` / `npx -y @upstash/context7-mcp --help` / `npx -y chrome-devtools-mcp@1.0.1 --help`: 正常
- `apm install` を marketplace 未登録環境で実行 → 直接 GitHub 経由でプラグイン取得成功
- `apm install` の冪等性確認 (2 回目以降は "already configured" / "files unchanged" / 更新後は "updated")
- `apm compile` で CLAUDE.md に新規 instructions セクション (`mcp-servers`, `apm-plugins`) が反映されることを確認

## Test plan

- [ ] `apm install` が 4 MCP + 2 APM プラグインを冪等にデプロイすること
- [ ] `.mcp.json` / `.vscode/mcp.json` / `.codex/config.toml` / `.agents/skills/` / `.claude/skills/` / `.claude/commands/` / `.claude/hooks/` / `.github/prompts/` が git status に出ない (.gitignore 効いている)
- [ ] `apm install` で `unpinned -- add #tag or #sha to prevent drift` 警告が出ないこと
- [ ] `apm compile` 後の `CLAUDE.md` に新規 `mcp-servers` / `apm-plugins` セクションが反映されること