### PR TITLE
apm.lock.yaml を git 追跡対象に追加

### DIFF
--- a/.apm/instructions/apm-plugins.instructions.md
+++ b/.apm/instructions/apm-plugins.instructions.md
@@ -1,0 +1,79 @@
+---
+description: APM (Agent Project Manager) を介した Claude Code プラグインの運用ルール
+applyTo: "apm.yml"
+---
+
+# APM プラグイン管理ルール
+
+## Source of Truth
+
+`apm.yml` の `dependencies.apm` がこのリポジトリで使う Claude Code プラグイン (Skills / commands / prompts / hooks 等のバンドル) の Source of Truth。
+`apm install` を実行すると、ここに宣言されたプラグインが `apm_modules/` にダウンロードされ、各成果物 (`.claude/skills/`, `.claude/commands/`, `.agents/skills/`, `.github/prompts/` 等) に展開される。
+
+## 配信されるプラグイン
+
+| プラグイン | リポジトリ | 用途 |
+| --- | --- | --- |
+| `code-review` | [anthropics/claude-code](https://github.com/anthropics/claude-code) (path: `plugins/code-review`) | PR の自動コードレビュー (複数の専門エージェントが confidence ベースで採点) |
+| `superpowers` | [obra/superpowers](https://github.com/obra/superpowers) | TDD・デバッグ・コラボレーションの汎用スキル群 (brainstorming, systematic-debugging, writing-plans 等 14 スキル) |
+
+## SHA ピン
+
+`dependencies.apm` のエントリは **必ず `#<sha>` でピンする**。`apm install` で `unpinned -- add #tag or #sha to prevent drift` という警告が出るため気付ける。
+
+```yaml
+dependencies:
+  apm:
+  - anthropics/claude-code/plugins/code-review#39e853e4074d90f27afdfb7ea601e0fc378bd0c5
+  - obra/superpowers#f2cbfbefebbfef77321e4c9abc9e949826bea9d7
+```
+
+理由: ピンしないと `apm install` 毎に上流の `main` を引いてしまい、各メンバーの開発体験が静かにドリフトする ([[apm_workflow]] のドリフト防止方針)。
+
+## プラグインの追加
+
+### marketplace 経由 (推奨。検索用)
+
+```bash
+# 1. marketplace を一時的に register (global config のみ。apm.yml には影響しない)
+apm marketplace add <owner>/<repo>
+# 2. plugin を install (apm.yml に追記される)
+apm install <plugin>@<marketplace-name>
+# 3. unpinned 警告が出るので apm.lock.yaml の resolved_commit を見て #sha でピン
+```
+
+### 直接 GitHub から (marketplace 未登録のプラグイン)
+
+```bash
+apm install <owner>/<repo>#<sha>
+# または path 指定
+apm install <owner>/<repo>/<path>#<sha>
+```
+
+`apm.yml` に `<owner>/<repo>[/<path>]#<sha>` 形式が直接書ければ、global の marketplace 登録は **不要**。
+チームメイトは `git clone` 後 `apm install` だけで同じプラグインを取得できる。
+
+## プラグインの削除
+
+`apm.yml` の `dependencies.apm` 配下から該当行を削除した後、`apm install` を再実行する。
+`apm_modules/<owner>/<repo>/` と展開済みファイルが残った場合は手動で掃除する。
+(`apm uninstall <package>` の動作は本リポジトリでは未検証)
+
+## 生成物の場所
+
+`apm install` がプラグインを展開する先。すべて `.gitignore` 対象。
+
+| パス | 由来 |
+| --- | --- |
+| `apm_modules/<owner>/<repo>/` | プラグインのソースコピー (cache) |
+| `.claude/skills/` | Claude Code Skills (SKILL.md) |
+| `.agents/skills/` | クロスクライアント Skills (Cursor / Codex / Gemini 等が読む) |
+| `.claude/commands/` | Claude Code スラッシュコマンド |
+| `.claude/hooks/` | Claude Code フックスクリプト |
+| `.claude/apm-hooks.json` | APM がフック登録に用いる索引 |
+| `.claude/settings.json` | フック有効化等のクライアント設定 |
+| `.github/prompts/` | GitHub Copilot プロンプト |
+| `.github/hooks/` | GitHub 用フック (Copilot CLI 等) |
+
+`.claude/settings.json` を ignore しているのは、APM がプラグインのフック有効化のために絶対パスを書き込むため (リポジトリで共有しても各環境でパスが食い違って意味がない)。
+個人の Claude Code 設定はユーザースコープ (`~/.claude/settings.json`) または `.claude/settings.local.json` (Claude Code の慣習で per-user 扱い) に置くこと。

--- a/.apm/instructions/apm-workflow.instructions.md
+++ b/.apm/instructions/apm-workflow.instructions.md
@@ -14,23 +14,29 @@ applyTo: ".apm/**"
 
 | パス | 役割 | リポジトリ追跡 |
 | --- | --- | --- |
-| `.apm/instructions/*.instructions.md` | **Source of Truth (人間が編集する)** | ✅ 追跡する |
+| `.apm/instructions/*.instructions.md` | **Source of Truth (instructions 用、人間が編集する)** | ✅ 追跡する |
+| `apm.yml` の `dependencies.mcp` | **Source of Truth (MCP サーバー用、人間が編集する)** | ✅ 追跡する |
 | `.github/copilot-instructions.md` | Copilot Code Review に SoT への参照を伝えるスタブ | ✅ 追跡する |
 | `.github/instructions/*.instructions.md` | `apm install` で生成 (Copilot 新形式) | ❌ 追跡しない |
 | `.claude/rules/*.md` | `apm install` で生成 (Claude Code 補助) | ❌ 追跡しない |
 | `CLAUDE.md` / `AGENTS.md` (各所) | `apm compile` で生成 | ❌ 追跡しない |
 | `apm.lock.yaml` | `apm install` で生成 | ❌ 追跡しない |
+| `.mcp.json` | `apm install` で生成 (Claude Code MCP 設定) | ❌ 追跡しない |
+| `.vscode/mcp.json` | `apm install` で生成 (GitHub Copilot in VS Code MCP 設定) | ❌ 追跡しない |
+| `.codex/config.toml` | `apm install` で生成 (Codex CLI MCP 設定) | ❌ 追跡しない |
 
 ## ローカルでの作業
 
-`.apm/instructions/` を編集後、ローカルで以下を実行することで生成物が更新される (任意)。
+`.apm/instructions/` または `apm.yml` を編集後、ローカルで以下を実行することで生成物が更新される (任意)。
 
 ```bash
-apm install   # .github/instructions/ と .claude/rules/ を更新
+apm install   # 全プリミティブを再デプロイ (.github/instructions/, .claude/rules/, .mcp.json, .vscode/mcp.json, .codex/config.toml)
 apm compile   # CLAUDE.md / AGENTS.md を更新
 ```
 
 ただし、生成物はすべて `.gitignore` 対象のためコミットには含まれない。
+
+MCP サーバーの追加・運用手順は [`mcp-servers.instructions.md`](./mcp-servers.instructions.md) を参照。
 
 ## GitHub Copilot Code Review への指示伝達
 

--- a/.apm/instructions/apm-workflow.instructions.md
+++ b/.apm/instructions/apm-workflow.instructions.md
@@ -16,6 +16,7 @@ applyTo: ".apm/**"
 | --- | --- | --- |
 | `.apm/instructions/*.instructions.md` | **Source of Truth (instructions 用、人間が編集する)** | ✅ 追跡する |
 | `apm.yml` の `dependencies.mcp` | **Source of Truth (MCP サーバー用、人間が編集する)** | ✅ 追跡する |
+| `apm.yml` の `dependencies.apm` | **Source of Truth (Claude Code プラグイン用、人間が編集する)** | ✅ 追跡する |
 | `.github/copilot-instructions.md` | Copilot Code Review に SoT への参照を伝えるスタブ | ✅ 追跡する |
 | `.github/instructions/*.instructions.md` | `apm install` で生成 (Copilot 新形式) | ❌ 追跡しない |
 | `.claude/rules/*.md` | `apm install` で生成 (Claude Code 補助) | ❌ 追跡しない |
@@ -24,6 +25,7 @@ applyTo: ".apm/**"
 | `.mcp.json` | `apm install` で生成 (Claude Code MCP 設定) | ❌ 追跡しない |
 | `.vscode/mcp.json` | `apm install` で生成 (GitHub Copilot in VS Code MCP 設定) | ❌ 追跡しない |
 | `.codex/config.toml` | `apm install` で生成 (Codex CLI MCP 設定) | ❌ 追跡しない |
+| `apm_modules/`, `.agents/skills/`, `.claude/skills/`, `.claude/commands/`, `.claude/hooks/`, `.claude/settings.json`, `.claude/apm-hooks.json`, `.github/prompts/`, `.github/hooks/` | `apm install` で生成 (APM プラグイン展開先) | ❌ 追跡しない |
 
 ## ローカルでの作業
 
@@ -37,6 +39,7 @@ apm compile   # CLAUDE.md / AGENTS.md を更新
 ただし、生成物はすべて `.gitignore` 対象のためコミットには含まれない。
 
 MCP サーバーの追加・運用手順は [`mcp-servers.instructions.md`](./mcp-servers.instructions.md) を参照。
+APM プラグイン (Skills / commands 等) の追加・運用手順は [`apm-plugins.instructions.md`](./apm-plugins.instructions.md) を参照。
 
 ## GitHub Copilot Code Review への指示伝達
 

--- a/.apm/instructions/mcp-servers.instructions.md
+++ b/.apm/instructions/mcp-servers.instructions.md
@@ -55,8 +55,11 @@ APM 公式レジストリ (`apm mcp search` / `apm mcp install <registry-name>`)
 | `.vscode/mcp.json` | GitHub Copilot in VS Code |
 | `.codex/config.toml` | Codex CLI |
 
-## APM の `--skill` プリミティブとの違い
+## APM の他のプリミティブとの違い
 
-APM には `--skill` フラグで扱う SKILL.md バンドル (Claude Code Skills) という別プリミティブが存在する。
-このリポジトリで管理しているのは **MCP サーバー** であり、APM の `--skill` プリミティブとは別概念。
-両者を混同しないこと。
+APM は MCP サーバーのほかに、以下のプリミティブも扱える。
+
+- **APM パッケージ (`dependencies.apm`)**: Skills (SKILL.md バンドル) / commands / prompts / hooks 等を含む Claude Code プラグインを GitHub から取得する。このリポジトリでは `code-review`, `superpowers` を採用 → [`apm-plugins.instructions.md`](./apm-plugins.instructions.md)
+- **APM スキル (`--skill` フラグ)**: SKILL_BUNDLE から個別の SKILL.md を選択的にインストール
+
+MCP サーバー / APM パッケージ / APM スキル はそれぞれ独立したプリミティブなので、用語を混同しないこと。

--- a/.apm/instructions/mcp-servers.instructions.md
+++ b/.apm/instructions/mcp-servers.instructions.md
@@ -1,0 +1,62 @@
+---
+description: APM (Agent Project Manager) を介した MCP サーバーの運用ルール
+applyTo: "apm.yml"
+---
+
+# MCP サーバー管理ルール
+
+## Source of Truth
+
+`apm.yml` の `dependencies.mcp` がこのリポジトリで使う MCP サーバーの Source of Truth。
+`apm install` を実行すると、ここに宣言された MCP サーバーが Claude Code / Codex CLI / GitHub Copilot (in VS Code) の各 IDE 設定に展開される。
+
+## 配信される MCP サーバー
+
+| 名前 | 起動コマンド | 用途 | 必要な前提 |
+| --- | --- | --- | --- |
+| `semgrep` | `uvx semgrep-mcp` | 静的解析 (SAST) によるコード品質・セキュリティ検査 | `uv` |
+| `chrome-devtools` | `npx chrome-devtools-mcp@latest` | Chrome DevTools 経由のブラウザ自動化・パフォーマンス計測 | `node` (Chrome は実行時にダウンロード) |
+| `serena` | `uvx --from git+https://github.com/oraios/serena serena start-mcp-server` | LSP ベースのシンボル指向コード探索・編集 | `uv` |
+| `context7` | `npx -y @upstash/context7-mcp` | ライブラリ公式ドキュメントの最新版を取得 | `node` |
+
+## 開発者の前提条件
+
+上記表の通り、以下のランタイムが PATH にあれば全 MCP サーバーが動作する。
+
+- [uv](https://docs.astral.sh/uv/) (`uvx` を経由して PyPI / git ソースの Python パッケージを実行)
+- [Node.js](https://nodejs.org/) (`npx` 経由)
+
+## サーバーの追加
+
+`apm install --mcp <name> -- <command> [args...]` で `apm.yml` に追記される。
+
+```bash
+# 例: 新しい MCP サーバーを追加
+apm install --mcp my-server -- npx -y @example/my-mcp
+```
+
+### APM レジストリは使わないこと
+
+APM 公式レジストリ (`apm mcp search` / `apm mcp install <registry-name>`) は 2026 年 5 月時点で
+解決結果が不正なケースがある (例: `oraios/serena` が `uvx ide-assistant` という別物に展開される)。
+このリポジトリでは **すべて self-defined (`-- <command> [args...]` 指定)** で登録する。
+
+## サーバーの削除
+
+`apm.yml` の `dependencies.mcp` 配下から該当エントリを手で削除した後、`apm install` を再実行する。
+
+## 生成物の場所
+
+`apm install` が以下のファイルを生成する。すべて `.gitignore` 対象。
+
+| パス | 対応 IDE |
+| --- | --- |
+| `.mcp.json` | Claude Code (project scope) |
+| `.vscode/mcp.json` | GitHub Copilot in VS Code |
+| `.codex/config.toml` | Codex CLI |
+
+## APM の `--skill` プリミティブとの違い
+
+APM には `--skill` フラグで扱う SKILL.md バンドル (Claude Code Skills) という別プリミティブが存在する。
+このリポジトリで管理しているのは **MCP サーバー** であり、APM の `--skill` プリミティブとは別概念。
+両者を混同しないこと。

--- a/.apm/instructions/mcp-servers.instructions.md
+++ b/.apm/instructions/mcp-servers.instructions.md
@@ -15,9 +15,24 @@ applyTo: "apm.yml"
 | 名前 | 起動コマンド | 用途 | 必要な前提 |
 | --- | --- | --- | --- |
 | `semgrep` | `uvx semgrep-mcp` | 静的解析 (SAST) によるコード品質・セキュリティ検査 | `uv` |
-| `chrome-devtools` | `npx chrome-devtools-mcp@latest` | Chrome DevTools 経由のブラウザ自動化・パフォーマンス計測 | `node` (Chrome は実行時にダウンロード) |
-| `serena` | `uvx --from git+https://github.com/oraios/serena serena start-mcp-server` | LSP ベースのシンボル指向コード探索・編集 | `uv` |
+| `chrome-devtools` | `npx -y chrome-devtools-mcp@1.0.1` | Chrome DevTools 経由のブラウザ自動化・パフォーマンス計測 | `node` (Chrome は実行時にダウンロード) |
+| `serena` | `uvx --from git+https://github.com/oraios/serena@c3a8d5a9c5 serena start-mcp-server` | LSP ベースのシンボル指向コード探索・編集 | `uv` |
 | `context7` | `npx -y @upstash/context7-mcp` | ライブラリ公式ドキュメントの最新版を取得 | `node` |
+
+## バージョン固定方針
+
+再現性確保のため、`@latest` や git ブランチ HEAD ではなく **具体バージョン or コミット SHA でピン** する ([[apm_workflow]] のドリフト防止方針)。
+
+- npm 系: `<package>@<semver>` (例: `chrome-devtools-mcp@1.0.1`)
+- git 系: `git+<url>@<sha>` (例: `git+https://github.com/oraios/serena@c3a8d5a9...`)
+- 例外: `semgrep-mcp` / `@upstash/context7-mcp` は API が安定しているため固定省略 (将来必要に応じて固定)
+
+更新するときは PR でレビュー可能な形に。`npm view <package> dist-tags` と `git ls-remote --tags <url>` で最新を確認。
+
+## npx の非対話起動
+
+`npx` は未インストールパッケージを実行する際に確認プロンプトを表示するため、`-y` (auto-yes) を必ず付ける。
+これがないと CI など非対話環境でハング・失敗する可能性がある。
 
 ## 開発者の前提条件
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,6 @@ src/js/*
 # APM の依存関係
 apm_modules/
 
-# APM のロックファイル (外部依存なし。generated_at とローカル生成物のハッシュのみを含むため追跡しない)
-apm.lock.yaml
-
 # APM コンパイル成果物 (.apm/ から `apm install` / `apm compile` で再生成されるため追跡しない)
 AGENTS.md
 CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,13 @@ CLAUDE.md
 .codex/
 .vscode/mcp.json
 .mcp.json
+
+# APM プラグイン (skills / commands / prompts / hooks / settings) の展開先 (apm.yml の dependencies.apm から `apm install` で再生成されるため追跡しない)
+.agents/skills/
+.claude/commands/
+.claude/skills/
+.claude/hooks/
+.claude/apm-hooks.json
+.claude/settings.json
+.github/prompts/
+.github/hooks/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ AGENTS.md
 CLAUDE.md
 .claude/rules/
 .github/instructions/
+
+# APM MCP 設定生成物 (apm.yml の dependencies.mcp から `apm install` で再生成されるため追跡しない)
+.codex/
+.vscode/mcp.json
+.mcp.json

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,0 +1,121 @@
+lockfile_version: '1'
+generated_at: '2026-05-23T04:39:00.951497+00:00'
+apm_version: 0.14.1
+dependencies:
+- repo_url: anthropics/claude-code
+  host: github.com
+  resolved_commit: 39e853e4074d90f27afdfb7ea601e0fc378bd0c5
+  resolved_ref: 39e853e4074d90f27afdfb7ea601e0fc378bd0c5
+  virtual_path: plugins/code-review
+  is_virtual: true
+  package_type: marketplace_plugin
+  deployed_files:
+  - .github/prompts/code-review.prompt.md
+  deployed_file_hashes:
+    .github/prompts/code-review.prompt.md: sha256:2b0837c5ec0b2e75f8ba4565bdafd76fa916b0dc146608c5733af7ba5802012c
+  content_hash: sha256:d25f797947bbd724551746c24ed4ac40788aaf370a7857eb120180fbb00ac2be
+- repo_url: obra/superpowers
+  host: github.com
+  resolved_commit: f2cbfbefebbfef77321e4c9abc9e949826bea9d7
+  resolved_ref: f2cbfbefebbfef77321e4c9abc9e949826bea9d7
+  package_type: marketplace_plugin
+  deployed_files:
+  - .agents/skills/brainstorming
+  - .agents/skills/dispatching-parallel-agents
+  - .agents/skills/executing-plans
+  - .agents/skills/finishing-a-development-branch
+  - .agents/skills/receiving-code-review
+  - .agents/skills/requesting-code-review
+  - .agents/skills/subagent-driven-development
+  - .agents/skills/systematic-debugging
+  - .agents/skills/test-driven-development
+  - .agents/skills/using-git-worktrees
+  - .agents/skills/using-superpowers
+  - .agents/skills/verification-before-completion
+  - .agents/skills/writing-plans
+  - .agents/skills/writing-skills
+  - .claude/hooks/superpowers/hooks/run-hook.cmd
+  - .claude/hooks/superpowers/hooks/run-hook.cmd
+  - .claude/skills/brainstorming
+  - .claude/skills/dispatching-parallel-agents
+  - .claude/skills/executing-plans
+  - .claude/skills/finishing-a-development-branch
+  - .claude/skills/receiving-code-review
+  - .claude/skills/requesting-code-review
+  - .claude/skills/subagent-driven-development
+  - .claude/skills/systematic-debugging
+  - .claude/skills/test-driven-development
+  - .claude/skills/using-git-worktrees
+  - .claude/skills/using-superpowers
+  - .claude/skills/verification-before-completion
+  - .claude/skills/writing-plans
+  - .claude/skills/writing-skills
+  - .codex/hooks/superpowers/hooks/run-hook.cmd
+  - .codex/hooks/superpowers/hooks/run-hook.cmd
+  deployed_file_hashes:
+    .claude/hooks/superpowers/hooks/run-hook.cmd: sha256:d3d9c6199678dab2858e60509dde5e7414f13c2a2b5e48a38b1d368b6e1d6abb
+    .codex/hooks/superpowers/hooks/run-hook.cmd: sha256:d3d9c6199678dab2858e60509dde5e7414f13c2a2b5e48a38b1d368b6e1d6abb
+  content_hash: sha256:fb4f87bfef928a6d68f5d5aaa29e3eba011961c5f03bbf171c3c348d8d161abb
+mcp_servers:
+- chrome-devtools
+- context7
+- semgrep
+- serena
+mcp_configs:
+  chrome-devtools:
+    name: chrome-devtools
+    transport: stdio
+    args:
+    - -y
+    - chrome-devtools-mcp@1.0.1
+    registry: false
+    command: npx
+  context7:
+    name: context7
+    transport: stdio
+    args:
+    - -y
+    - '@upstash/context7-mcp'
+    registry: false
+    command: npx
+  semgrep:
+    name: semgrep
+    transport: stdio
+    args:
+    - semgrep-mcp
+    registry: false
+    command: uvx
+  serena:
+    name: serena
+    transport: stdio
+    args:
+    - --from
+    - git+https://github.com/oraios/serena@c3a8d5a9c54622c8ce771a54e5feffd6efda8749
+    - serena
+    - start-mcp-server
+    registry: false
+    command: uvx
+local_deployed_files:
+- .claude/rules/apm-plugins.md
+- .github/instructions/apm-plugins.instructions.md
+- .github/instructions/dev-workflow.instructions.md
+- .github/instructions/feature-spec.instructions.md
+- .github/instructions/github-ops.instructions.md
+- .github/instructions/lint.instructions.md
+- .github/instructions/mcp-servers.instructions.md
+- .github/instructions/pr-review.instructions.md
+- .github/instructions/setup.instructions.md
+- .github/instructions/styling.instructions.md
+- .github/instructions/typescript.instructions.md
+local_deployed_file_hashes:
+  .claude/rules/apm-plugins.md: sha256:3c7744735e2a9bf947479a60ef782219d8fd803068c8d62c89003cc65e81cae0
+  .github/instructions/apm-plugins.instructions.md: sha256:d6039ef3d7c34ceb2df416621e403459a1833dfdf6a7aa0cf5093eddb686817a
+  .github/instructions/dev-workflow.instructions.md: sha256:ec98fdd06c5a93ff0597c221f4f0967db63df591d32c16da8cec0177f656398b
+  .github/instructions/feature-spec.instructions.md: sha256:d641da9a56e032cef5b7d8d29a0cc2a472723b9848a5906bd02f1bf211165e07
+  .github/instructions/github-ops.instructions.md: sha256:618e6525ce967083cf32c25deca4c6255dd78465981b345588a323789d4dcf50
+  .github/instructions/lint.instructions.md: sha256:e4d1c252de1773dfe9aa7d7fa2a4f63e6ee9f07fa04cebabca3ff9a1ad72da1a
+  .github/instructions/mcp-servers.instructions.md: sha256:5d54f740a01c54c6400e089c3fe62c7aefb7cf781a6e2b215bcffc82423374ce
+  .github/instructions/pr-review.instructions.md: sha256:d785037a0bfc858b8b6711bd9b17c01f0213a7b3c07959cd13dec253004acacd
+  .github/instructions/setup.instructions.md: sha256:5719277129c59f6cfd948150655583a11118140df0325727c44e2c5cf9e0195d
+  .github/instructions/styling.instructions.md: sha256:cfb5373ec78a677e02ba28c87774ac78a172790aae88eae3b23dd7837398d9b1
+  .github/instructions/typescript.instructions.md: sha256:eb50e1ca4f5e22c9fc142e8d112f2635016d8fc872beb870f3e9eb333b9dc392

--- a/apm.yml
+++ b/apm.yml
@@ -22,14 +22,15 @@ dependencies:
     transport: stdio
     command: npx
     args:
-    - chrome-devtools-mcp@latest
+    - -y
+    - chrome-devtools-mcp@1.0.1
   - name: serena
     registry: false
     transport: stdio
     command: uvx
     args:
     - --from
-    - git+https://github.com/oraios/serena
+    - git+https://github.com/oraios/serena@c3a8d5a9c54622c8ce771a54e5feffd6efda8749
     - serena
     - start-mcp-server
   - name: context7

--- a/apm.yml
+++ b/apm.yml
@@ -1,19 +1,41 @@
-# APM (Agent Project Manager) マニフェスト
-# 参考: https://github.com/microsoft/apm
 name: bingo-machine
 version: 1.6.5
 description: AI agent instructions for the Bingo Machine project
 author: ROhta
 license: GPL-3.0-or-later
-
-# 単一目的: このパッケージは instructions プリミティブのみを配信する
 type: instructions
-
-# コンパイル対象: Claude Code, Codex CLI, GitHub Copilot
-target:
-  - claude
-  - codex
-  - copilot
-
-# .apm/ 配下のすべてのプリミティブを自動公開
+targets:
+- claude
+- codex
+- copilot
 includes: auto
+dependencies:
+  mcp:
+  - name: semgrep
+    registry: false
+    transport: stdio
+    command: uvx
+    args:
+    - semgrep-mcp
+  - name: chrome-devtools
+    registry: false
+    transport: stdio
+    command: npx
+    args:
+    - chrome-devtools-mcp@latest
+  - name: serena
+    registry: false
+    transport: stdio
+    command: uvx
+    args:
+    - --from
+    - git+https://github.com/oraios/serena
+    - serena
+    - start-mcp-server
+  - name: context7
+    registry: false
+    transport: stdio
+    command: npx
+    args:
+    - -y
+    - '@upstash/context7-mcp'

--- a/apm.yml
+++ b/apm.yml
@@ -39,3 +39,6 @@ dependencies:
     args:
     - -y
     - '@upstash/context7-mcp'
+  apm:
+  - anthropics/claude-code/plugins/code-review#39e853e4074d90f27afdfb7ea601e0fc378bd0c5
+  - obra/superpowers#f2cbfbefebbfef77321e4c9abc9e949826bea9d7


### PR DESCRIPTION
## Summary

- `.gitignore` から `apm.lock.yaml` を除外し、ロックファイルを追跡対象に変更
- APM 公式仕様 ([lockfile-spec.md](https://github.com/microsoft/apm/blob/main/docs/src/content/docs/reference/lockfile-spec.md)) の "Always commit it. The lockfile is what makes a fresh clone install identically on any machine." に従う
- pnpm-lock.yaml をコミットしている本リポジトリのロックファイル管理哲学と揃える

## なぜ追跡するのか

APM 公式仕様が挙げるロックファイルの目的のうち、`apm.yml` の SHA ピンだけでは得られない以下の価値を取り込む:

| 価値 | 提供フィールド | 用途 |
| --- | --- | --- |
| 整合性検証 | `deployed_file_hashes` | `apm audit` で展開ファイルの改ざんを検出 (サプライチェーン耐性) |
| オーファン検出 | `deployed_files` | `apm prune` が不要ファイルを正確に削除 |
| 厳密な再現性 | `resolved_commit` 一覧 | `apm install --frozen` で解決処理を完全スキップ |
| 監査参照点 | `generated_at` / `apm_version` | drift 発生時に「いつ・どの CLI で書かれたか」を追跡 |

## `generated_at` の diff churn について

APM 側で対策済みのため、本変更後も diff ノイズは発生しません:

1. **`_write_if_changed` ガード**: [`src/apm_cli/install/phases/lockfile.py`](https://github.com/microsoft/apm/blob/main/src/apm_cli/install/phases/lockfile.py) が「セマンティック内容が変わったときだけ書き込む」設計。コメントにも明示的に `# (avoids generated_at churn in version control)` と記載
2. **仕様上の除外**: `generated_at` は "Ignored by equivalence checks." と仕様に明記されており、等価性比較からは外れる

`apm install` を毎回実行しても、依存解決結果が変わらない限りファイル書き込み自体が走らないため、git の diff には現れません。

## 動作確認

- [x] `git check-ignore -v apm.lock.yaml` が無視対象でないことを確認
- [x] `git add apm.lock.yaml` が成功
- [ ] レビュアー側で `apm install` 実行後の `git diff apm.lock.yaml` が空であることを確認 (依存に変更が無ければ)