### PR TITLE
APM の code-review をベンダー非依存 OSS (awesome-copilot) に置換、バージョンを 2.0.1 に揃える

### DIFF
--- a/.apm/instructions/apm-plugins.instructions.md
+++ b/.apm/instructions/apm-plugins.instructions.md
@@ -25,6 +25,16 @@ applyTo: "apm.yml"
 
 `dependencies.apm` には特定 AI ベンダー (anthropics 等) 組織配下のリポジトリを直接指定せず、コミュニティ curated marketplace (`github/awesome-copilot`) や中立 OSS 作者リポジトリ (`obra/superpowers`) を経由する。理由: ベンダー組織のプラグインは「そのベンダーのランタイム前提」 (例: Claude Code の Stop hook + subagent 機構) で書かれていることが多く、Codex などのターゲットに同等機能が配信されないため。
 
+## インストール手順 (`pnpm apm-install`)
+
+APM CLI v0.14.1 には `apm install` 後の `apm.lock.yaml` の `deployed_files:` 配列に同一パスが 2 回ずつ記録される既知の不具合がある (例: `obra/superpowers` 由来の `run-hook.cmd` 等が重複)。差分ノイズや整合性チェック誤検知の原因になるため、本リポジトリでは `apm install` を直接呼ばず以下のラッパー経由で実行する。
+
+```bash
+pnpm apm-install   # = apm install && node scripts/dedupe-apm-lock.mjs
+```
+
+`scripts/dedupe-apm-lock.mjs` は隣接した同一 `- <path>` 行を 1 行に畳む後処理 (YAML パーサ非依存・新規 devDep 不要)。`deployed_file_hashes:` (mapping) は配列ではないため影響を受けない。upstream ([microsoft/apm](https://github.com/microsoft/apm)) で fix され次第、このラッパーと dedupe スクリプトは撤去する。
+
 ## SHA ピン
 
 `dependencies.apm` のエントリは **必ず `#<sha>` でピンする**。`apm install` で `unpinned -- add #tag or #sha to prevent drift` という警告が出るため気付ける。

--- a/.apm/instructions/apm-plugins.instructions.md
+++ b/.apm/instructions/apm-plugins.instructions.md
@@ -7,15 +7,18 @@ applyTo: "apm.yml"
 
 ## Source of Truth
 
-`apm.yml` の `dependencies.apm` がこのリポジトリで使う Claude Code プラグイン (Skills / commands / prompts / hooks 等のバンドル) の Source of Truth。
-`apm install` を実行すると、ここに宣言されたプラグインが `apm_modules/` にダウンロードされ、各成果物 (`.claude/skills/`, `.claude/commands/`, `.agents/skills/`, `.github/prompts/` 等) に展開される。
+`apm.yml` の `dependencies.apm` がこのリポジトリで使う Claude Code プラグイン (Skills / commands / prompts / hooks 等のバンドル) の Source of Truth。 `apm install` を実行すると、ここに宣言されたプラグインが `apm_modules/` にダウンロードされ、各成果物 (`.claude/skills/`, `.claude/commands/`, `.agents/skills/`, `.github/prompts/` 等) に展開される。
 
 ## 配信されるプラグイン
 
-| プラグイン | リポジトリ | 用途 |
-| --- | --- | --- |
-| `code-review` | [anthropics/claude-code](https://github.com/anthropics/claude-code) (path: `plugins/code-review`) | PR の自動コードレビュー (複数の専門エージェントが confidence ベースで採点) |
-| `superpowers` | [obra/superpowers](https://github.com/obra/superpowers) | TDD・デバッグ・コラボレーションの汎用スキル群 (brainstorming, systematic-debugging, writing-plans 等 14 スキル) |
+| 依存                                  | リポジトリ                                                                                                                     | 種別                            | 用途                                                                                                                                                                    |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `code-review-generic.instructions.md` | [github/awesome-copilot](https://github.com/github/awesome-copilot) (path: `instructions/code-review-generic.instructions.md`) | 単一プリミティブ (virtual file) | 汎用コードレビュー指示 (ベンダー・言語・プロジェクト非依存)。Claude (`.claude/rules/`) と Copilot (`.github/instructions/`) に展開、Codex は `AGENTS.md` 経由で受け取る |
+| `superpowers`                         | [obra/superpowers](https://github.com/obra/superpowers)                                                                        | marketplace plugin              | TDD・デバッグ・コラボレーションの汎用スキル群 (brainstorming, systematic-debugging, writing-plans 等 14 スキル)                                                         |
+
+### vendor-neutral 方針
+
+`dependencies.apm` には特定 AI ベンダー (anthropics 等) 組織配下のリポジトリを直接指定せず、コミュニティ curated marketplace (`github/awesome-copilot`) や中立 OSS 作者リポジトリ (`obra/superpowers`) を経由する。理由: ベンダー組織のプラグインは「そのベンダーのランタイム前提」 (例: Claude Code の Stop hook + subagent 機構) で書かれていることが多く、Codex などのターゲットに同等機能が配信されないため。
 
 ## SHA ピン
 
@@ -24,8 +27,8 @@ applyTo: "apm.yml"
 ```yaml
 dependencies:
   apm:
-  - anthropics/claude-code/plugins/code-review#39e853e4074d90f27afdfb7ea601e0fc378bd0c5
-  - obra/superpowers#f2cbfbefebbfef77321e4c9abc9e949826bea9d7
+    - github/awesome-copilot/instructions/code-review-generic.instructions.md#5b049e4e196c10aab8ddfd9e492323d08cf985b0
+    - obra/superpowers#f2cbfbefebbfef77321e4c9abc9e949826bea9d7
 ```
 
 理由: ピンしないと `apm install` 毎に上流の `main` を引いてしまい、各メンバーの開発体験が静かにドリフトする ([[apm_workflow]] のドリフト防止方針)。
@@ -46,34 +49,34 @@ apm install <plugin>@<marketplace-name>
 
 ```bash
 apm install <owner>/<repo>#<sha>
-# または path 指定
+# または path 指定 (プラグイン bundle のサブディレクトリ)
 apm install <owner>/<repo>/<path>#<sha>
+# または単一プリミティブファイル (instructions / prompts / skills など 1 ファイル指定)
+apm install <owner>/<repo>/<path-to-file>.<ext>.md#<sha>
 ```
 
-`apm.yml` に `<owner>/<repo>[/<path>]#<sha>` 形式が直接書ければ、global の marketplace 登録は **不要**。
-チームメイトは `git clone` 後 `apm install` だけで同じプラグインを取得できる。
+`apm.yml` に `<owner>/<repo>[/<path>]#<sha>` 形式が直接書ければ、global の marketplace 登録は **不要**。チームメイトは `git clone` 後 `apm install` だけで同じプラグインを取得できる。
+
+`<path-to-file>.instructions.md` のように **末尾がファイル名** の場合、APM は単一プリミティブ (virtual file) として取り込む。プラグイン全体を取り込まずに必要な 1 ファイルだけを依存にしたい時 (例: 汎用 instructions のみが欲しいケース) に使う。
 
 ## プラグインの削除
 
-`apm.yml` の `dependencies.apm` 配下から該当行を削除した後、`apm install` を再実行する。
-`apm_modules/<owner>/<repo>/` と展開済みファイルが残った場合は手動で掃除する。
-(`apm uninstall <package>` の動作は本リポジトリでは未検証)
+`apm.yml` の `dependencies.apm` 配下から該当行を削除した後、`apm install` を再実行する。 `apm_modules/<owner>/<repo>/` と展開済みファイルが残った場合は手動で掃除する。(`apm uninstall <package>` の動作は本リポジトリでは未検証)
 
 ## 生成物の場所
 
 `apm install` がプラグインを展開する先。すべて `.gitignore` 対象。
 
-| パス | 由来 |
-| --- | --- |
-| `apm_modules/<owner>/<repo>/` | プラグインのソースコピー (cache) |
-| `.claude/skills/` | Claude Code Skills (SKILL.md) |
-| `.agents/skills/` | クロスクライアント Skills (Cursor / Codex / Gemini 等が読む) |
-| `.claude/commands/` | Claude Code スラッシュコマンド |
-| `.claude/hooks/` | Claude Code フックスクリプト |
-| `.claude/apm-hooks.json` | APM がフック登録に用いる索引 |
-| `.claude/settings.json` | フック有効化等のクライアント設定 |
-| `.github/prompts/` | GitHub Copilot プロンプト |
-| `.github/hooks/` | GitHub 用フック (Copilot CLI 等) |
+| パス                          | 由来                                                         |
+| ----------------------------- | ------------------------------------------------------------ |
+| `apm_modules/<owner>/<repo>/` | プラグインのソースコピー (cache)                             |
+| `.claude/skills/`             | Claude Code Skills (SKILL.md)                                |
+| `.agents/skills/`             | クロスクライアント Skills (Cursor / Codex / Gemini 等が読む) |
+| `.claude/commands/`           | Claude Code スラッシュコマンド                               |
+| `.claude/hooks/`              | Claude Code フックスクリプト                                 |
+| `.claude/apm-hooks.json`      | APM がフック登録に用いる索引                                 |
+| `.claude/settings.json`       | フック有効化等のクライアント設定                             |
+| `.github/prompts/`            | GitHub Copilot プロンプト                                    |
+| `.github/hooks/`              | GitHub 用フック (Copilot CLI 等)                             |
 
-`.claude/settings.json` を ignore しているのは、APM がプラグインのフック有効化のために絶対パスを書き込むため (リポジトリで共有しても各環境でパスが食い違って意味がない)。
-個人の Claude Code 設定はユーザースコープ (`~/.claude/settings.json`) または `.claude/settings.local.json` (Claude Code の慣習で per-user 扱い) に置くこと。
+`.claude/settings.json` を ignore しているのは、APM がプラグインのフック有効化のために絶対パスを書き込むため (リポジトリで共有しても各環境でパスが食い違って意味がない)。個人の Claude Code 設定はユーザースコープ (`~/.claude/settings.json`) または `.claude/settings.local.json` (Claude Code の慣習で per-user 扱い) に置くこと。

--- a/.apm/instructions/apm-plugins.instructions.md
+++ b/.apm/instructions/apm-plugins.instructions.md
@@ -1,5 +1,5 @@
 ---
-description: APM (Agent Project Manager) を介した Claude Code プラグインの運用ルール
+description: APM (Agent Project Manager) を介した依存パッケージ (プラグイン bundle / 単一プリミティブ) の運用ルール
 applyTo: "apm.yml"
 ---
 
@@ -7,7 +7,12 @@ applyTo: "apm.yml"
 
 ## Source of Truth
 
-`apm.yml` の `dependencies.apm` がこのリポジトリで使う Claude Code プラグイン (Skills / commands / prompts / hooks 等のバンドル) の Source of Truth。 `apm install` を実行すると、ここに宣言されたプラグインが `apm_modules/` にダウンロードされ、各成果物 (`.claude/skills/`, `.claude/commands/`, `.agents/skills/`, `.github/prompts/` 等) に展開される。
+`apm.yml` の `dependencies.apm` がこのリポジトリで使う APM 依存パッケージの Source of Truth。扱える形態は 2 種類:
+
+- **プラグイン bundle**: Skills (SKILL.md) / commands / prompts / hooks / instructions / agents 等を 1 リポジトリにまとめたもの (例: `obra/superpowers`)
+- **単一プリミティブ (virtual file)**: 既存リポジトリ内の特定の `*.instructions.md` / `*.prompt.md` / `SKILL.md` などを 1 ファイル単位で取り込むもの (例: `github/awesome-copilot/instructions/code-review-generic.instructions.md`)
+
+`apm install` を実行すると、ここに宣言された依存が `apm_modules/` にダウンロードされ、各ターゲット向けに `.claude/rules/`, `.claude/skills/`, `.claude/commands/`, `.claude/hooks/`, `.agents/skills/`, `.github/instructions/`, `.github/prompts/`, `.github/hooks/` 等へ展開される (内容に応じて配信先が変わる)。Codex 向けには専用の配信先を持たない代わりに、`apm compile` 時に instructions / skills 内容が `AGENTS.md` に組み込まれる。
 
 ## 配信されるプラグイン
 
@@ -67,16 +72,18 @@ apm install <owner>/<repo>/<path-to-file>.<ext>.md#<sha>
 
 `apm install` がプラグインを展開する先。すべて `.gitignore` 対象。
 
-| パス                          | 由来                                                         |
-| ----------------------------- | ------------------------------------------------------------ |
-| `apm_modules/<owner>/<repo>/` | プラグインのソースコピー (cache)                             |
-| `.claude/skills/`             | Claude Code Skills (SKILL.md)                                |
-| `.agents/skills/`             | クロスクライアント Skills (Cursor / Codex / Gemini 等が読む) |
-| `.claude/commands/`           | Claude Code スラッシュコマンド                               |
-| `.claude/hooks/`              | Claude Code フックスクリプト                                 |
-| `.claude/apm-hooks.json`      | APM がフック登録に用いる索引                                 |
-| `.claude/settings.json`       | フック有効化等のクライアント設定                             |
-| `.github/prompts/`            | GitHub Copilot プロンプト                                    |
-| `.github/hooks/`              | GitHub 用フック (Copilot CLI 等)                             |
+| パス                          | 由来                                                                         |
+| ----------------------------- | ---------------------------------------------------------------------------- |
+| `apm_modules/<owner>/<repo>/` | 依存のソースコピー (cache)                                                   |
+| `.claude/rules/`              | Claude Code 用 instructions (virtual file の `*.instructions.md` 等の展開先) |
+| `.claude/skills/`             | Claude Code Skills (SKILL.md)                                                |
+| `.agents/skills/`             | クロスクライアント Skills (Cursor / Codex / Gemini 等が読む)                 |
+| `.claude/commands/`           | Claude Code スラッシュコマンド                                               |
+| `.claude/hooks/`              | Claude Code フックスクリプト                                                 |
+| `.claude/apm-hooks.json`      | APM がフック登録に用いる索引                                                 |
+| `.claude/settings.json`       | フック有効化等のクライアント設定                                             |
+| `.github/instructions/`       | GitHub Copilot 用 instructions (`*.instructions.md`)                         |
+| `.github/prompts/`            | GitHub Copilot プロンプト (`*.prompt.md`)                                    |
+| `.github/hooks/`              | GitHub 用フック (Copilot CLI 等)                                             |
 
 `.claude/settings.json` を ignore しているのは、APM がプラグインのフック有効化のために絶対パスを書き込むため (リポジトリで共有しても各環境でパスが食い違って意味がない)。個人の Claude Code 設定はユーザースコープ (`~/.claude/settings.json`) または `.claude/settings.local.json` (Claude Code の慣習で per-user 扱い) に置くこと。

--- a/.apm/instructions/apm-workflow.instructions.md
+++ b/.apm/instructions/apm-workflow.instructions.md
@@ -7,49 +7,45 @@ applyTo: ".apm/**"
 
 ## Source of Truth
 
-`.apm/instructions/*.instructions.md` がすべての AI エージェント向け指示の Source of Truth。
-ここを編集することで、Claude Code / Codex CLI / GitHub Copilot すべてに同じ指示が届く。
+`.apm/instructions/*.instructions.md` がすべての AI エージェント向け指示の Source of Truth。ここを編集することで、Claude Code / Codex CLI / GitHub Copilot すべてに同じ指示が届く。
 
 ## ファイルの管理方針
 
-| パス | 役割 | リポジトリ追跡 |
-| --- | --- | --- |
-| `.apm/instructions/*.instructions.md` | **Source of Truth (instructions 用、人間が編集する)** | ✅ 追跡する |
-| `apm.yml` の `dependencies.mcp` | **Source of Truth (MCP サーバー用、人間が編集する)** | ✅ 追跡する |
-| `apm.yml` の `dependencies.apm` | **Source of Truth (Claude Code プラグイン用、人間が編集する)** | ✅ 追跡する |
-| `.github/copilot-instructions.md` | Copilot Code Review に SoT への参照を伝えるスタブ | ✅ 追跡する |
-| `.github/instructions/*.instructions.md` | `apm install` で生成 (Copilot 新形式) | ❌ 追跡しない |
-| `.claude/rules/*.md` | `apm install` で生成 (Claude Code 補助) | ❌ 追跡しない |
-| `CLAUDE.md` / `AGENTS.md` (各所) | `apm compile` で生成 | ❌ 追跡しない |
-| `apm.lock.yaml` | `apm install` で生成 (整合性検証・オーファン検出・厳密な再現性のため例外的に追跡) | ✅ 追跡する |
-| `.mcp.json` | `apm install` で生成 (Claude Code MCP 設定) | ❌ 追跡しない |
-| `.vscode/mcp.json` | `apm install` で生成 (GitHub Copilot in VS Code MCP 設定) | ❌ 追跡しない |
-| `.codex/config.toml` | `apm install` で生成 (Codex CLI MCP 設定) | ❌ 追跡しない |
-| `apm_modules/`, `.agents/skills/`, `.claude/skills/`, `.claude/commands/`, `.claude/hooks/`, `.claude/settings.json`, `.claude/apm-hooks.json`, `.github/prompts/`, `.github/hooks/` | `apm install` で生成 (APM プラグイン展開先) | ❌ 追跡しない |
+| パス                                                                                                                                                                                 | 役割                                                                              | リポジトリ追跡 |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- | -------------- |
+| `.apm/instructions/*.instructions.md`                                                                                                                                                | **Source of Truth (instructions 用、人間が編集する)**                             | ✅ 追跡する    |
+| `apm.yml` の `dependencies.mcp`                                                                                                                                                      | **Source of Truth (MCP サーバー用、人間が編集する)**                              | ✅ 追跡する    |
+| `apm.yml` の `dependencies.apm`                                                                                                                                                      | **Source of Truth (Claude Code プラグイン用、人間が編集する)**                    | ✅ 追跡する    |
+| `.github/copilot-instructions.md`                                                                                                                                                    | Copilot Code Review に SoT への参照を伝えるスタブ                                 | ✅ 追跡する    |
+| `.github/instructions/*.instructions.md`                                                                                                                                             | `apm install` で生成 (Copilot 新形式)                                             | ❌ 追跡しない  |
+| `.claude/rules/*.md`                                                                                                                                                                 | `apm install` で生成 (Claude Code 補助)                                           | ❌ 追跡しない  |
+| `CLAUDE.md` / `AGENTS.md` (各所)                                                                                                                                                     | `apm compile` で生成                                                              | ❌ 追跡しない  |
+| `apm.lock.yaml`                                                                                                                                                                      | `apm install` で生成 (整合性検証・オーファン検出・厳密な再現性のため例外的に追跡) | ✅ 追跡する    |
+| `.mcp.json`                                                                                                                                                                          | `apm install` で生成 (Claude Code MCP 設定)                                       | ❌ 追跡しない  |
+| `.vscode/mcp.json`                                                                                                                                                                   | `apm install` で生成 (GitHub Copilot in VS Code MCP 設定)                         | ❌ 追跡しない  |
+| `.codex/config.toml`                                                                                                                                                                 | `apm install` で生成 (Codex CLI MCP 設定)                                         | ❌ 追跡しない  |
+| `apm_modules/`, `.agents/skills/`, `.claude/skills/`, `.claude/commands/`, `.claude/hooks/`, `.claude/settings.json`, `.claude/apm-hooks.json`, `.github/prompts/`, `.github/hooks/` | `apm install` で生成 (APM プラグイン展開先)                                       | ❌ 追跡しない  |
 
 ## ローカルでの作業
 
 `.apm/instructions/` または `apm.yml` を編集後、ローカルで以下を実行することで生成物が更新される (任意)。
 
 ```bash
-apm install   # 全プリミティブを再デプロイ (.github/instructions/, .claude/rules/, .mcp.json, .vscode/mcp.json, .codex/config.toml)
-apm compile   # CLAUDE.md / AGENTS.md を更新
+pnpm apm-install   # = apm install && scripts/dedupe-apm-lock.mjs (lockfile 重複除去) → 全プリミティブを再デプロイ (.github/instructions/, .claude/rules/, .mcp.json, .vscode/mcp.json, .codex/config.toml)
+apm compile        # CLAUDE.md / AGENTS.md を更新
 ```
 
-ただし、`apm.lock.yaml` を除く生成物は `.gitignore` 対象のためコミットには含まれない。
+ただし、`apm.lock.yaml` を除く生成物は `.gitignore` 対象のためコミットには含まれない。 `pnpm apm-install` を `apm install` 直接呼びで代用しないこと (APM CLI v0.14.1 の既知不具合で `deployed_files:` に重複が残るため。詳細は [`apm-plugins.instructions.md`](./apm-plugins.instructions.md))。
 
-MCP サーバーの追加・運用手順は [`mcp-servers.instructions.md`](./mcp-servers.instructions.md) を参照。
-APM プラグイン (Skills / commands 等) の追加・運用手順は [`apm-plugins.instructions.md`](./apm-plugins.instructions.md) を参照。
+MCP サーバーの追加・運用手順は [`mcp-servers.instructions.md`](./mcp-servers.instructions.md) を参照。APM プラグイン (Skills / commands 等) の追加・運用手順は [`apm-plugins.instructions.md`](./apm-plugins.instructions.md) を参照。
 
 ## GitHub Copilot Code Review への指示伝達
 
-2026 年 5 月時点、GitHub Copilot Code Review エージェントは `AGENTS.md` を読まず、
-`.github/copilot-instructions.md` または `.github/instructions/*.instructions.md` のみを読む仕様。
+2026 年 5 月時点、GitHub Copilot Code Review エージェントは `AGENTS.md` を読まず、 `.github/copilot-instructions.md` または `.github/instructions/*.instructions.md` のみを読む仕様。
 
-このリポジトリでは `.github/copilot-instructions.md` をスタブとして配置し、
-SoT である `.apm/instructions/pr-review.instructions.md` を参照する形式で
-Copilot Code Review に指示の所在を伝えている。
+このリポジトリでは `.github/copilot-instructions.md` をスタブとして配置し、SoT である `.apm/instructions/pr-review.instructions.md` を参照する形式で Copilot Code Review に指示の所在を伝えている。
 
 参考:
+
 - <https://docs.github.com/copilot/how-tos/configure-custom-instructions/add-repository-instructions>
 - <https://github.com/orgs/community/discussions/174058>

--- a/.apm/instructions/mcp-servers.instructions.md
+++ b/.apm/instructions/mcp-servers.instructions.md
@@ -7,17 +7,16 @@ applyTo: "apm.yml"
 
 ## Source of Truth
 
-`apm.yml` の `dependencies.mcp` がこのリポジトリで使う MCP サーバーの Source of Truth。
-`apm install` を実行すると、ここに宣言された MCP サーバーが Claude Code / Codex CLI / GitHub Copilot (in VS Code) の各 IDE 設定に展開される。
+`apm.yml` の `dependencies.mcp` がこのリポジトリで使う MCP サーバーの Source of Truth。 `apm install` を実行すると、ここに宣言された MCP サーバーが Claude Code / Codex CLI / GitHub Copilot (in VS Code) の各 IDE 設定に展開される。
 
 ## 配信される MCP サーバー
 
-| 名前 | 起動コマンド | 用途 | 必要な前提 |
-| --- | --- | --- | --- |
-| `semgrep` | `uvx semgrep-mcp` | 静的解析 (SAST) によるコード品質・セキュリティ検査 | `uv` |
-| `chrome-devtools` | `npx -y chrome-devtools-mcp@1.0.1` | Chrome DevTools 経由のブラウザ自動化・パフォーマンス計測 | `node` (Chrome は実行時にダウンロード) |
-| `serena` | `uvx --from git+https://github.com/oraios/serena@c3a8d5a9c5 serena start-mcp-server` | LSP ベースのシンボル指向コード探索・編集 | `uv` |
-| `context7` | `npx -y @upstash/context7-mcp` | ライブラリ公式ドキュメントの最新版を取得 | `node` |
+| 名前              | 起動コマンド                                                                         | 用途                                                     | 必要な前提                             |
+| ----------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------- | -------------------------------------- |
+| `semgrep`         | `uvx semgrep-mcp`                                                                    | 静的解析 (SAST) によるコード品質・セキュリティ検査       | `uv`                                   |
+| `chrome-devtools` | `npx -y chrome-devtools-mcp@1.0.1`                                                   | Chrome DevTools 経由のブラウザ自動化・パフォーマンス計測 | `node` (Chrome は実行時にダウンロード) |
+| `serena`          | `uvx --from git+https://github.com/oraios/serena@c3a8d5a9c5 serena start-mcp-server` | LSP ベースのシンボル指向コード探索・編集                 | `uv`                                   |
+| `context7`        | `npx -y @upstash/context7-mcp`                                                       | ライブラリ公式ドキュメントの最新版を取得                 | `node`                                 |
 
 ## バージョン固定方針
 
@@ -31,8 +30,7 @@ applyTo: "apm.yml"
 
 ## npx の非対話起動
 
-`npx` は未インストールパッケージを実行する際に確認プロンプトを表示するため、`-y` (auto-yes) を必ず付ける。
-これがないと CI など非対話環境でハング・失敗する可能性がある。
+`npx` は未インストールパッケージを実行する際に確認プロンプトを表示するため、`-y` (auto-yes) を必ず付ける。これがないと CI など非対話環境でハング・失敗する可能性がある。
 
 ## 開発者の前提条件
 
@@ -52,9 +50,7 @@ apm install --mcp my-server -- npx -y @example/my-mcp
 
 ### APM レジストリは使わないこと
 
-APM 公式レジストリ (`apm mcp search` / `apm mcp install <registry-name>`) は 2026 年 5 月時点で
-解決結果が不正なケースがある (例: `oraios/serena` が `uvx ide-assistant` という別物に展開される)。
-このリポジトリでは **すべて self-defined (`-- <command> [args...]` 指定)** で登録する。
+APM 公式レジストリ (`apm mcp search` / `apm mcp install <registry-name>`) は 2026 年 5 月時点で解決結果が不正なケースがある (例: `oraios/serena` が `uvx ide-assistant` という別物に展開される)。このリポジトリでは **すべて self-defined (`-- <command> [args...]` 指定)** で登録する。
 
 ## サーバーの削除
 
@@ -64,17 +60,17 @@ APM 公式レジストリ (`apm mcp search` / `apm mcp install <registry-name>`)
 
 `apm install` が以下のファイルを生成する。すべて `.gitignore` 対象。
 
-| パス | 対応 IDE |
-| --- | --- |
-| `.mcp.json` | Claude Code (project scope) |
-| `.vscode/mcp.json` | GitHub Copilot in VS Code |
-| `.codex/config.toml` | Codex CLI |
+| パス                 | 対応 IDE                    |
+| -------------------- | --------------------------- |
+| `.mcp.json`          | Claude Code (project scope) |
+| `.vscode/mcp.json`   | GitHub Copilot in VS Code   |
+| `.codex/config.toml` | Codex CLI                   |
 
 ## APM の他のプリミティブとの違い
 
 APM は MCP サーバーのほかに、以下のプリミティブも扱える。
 
-- **APM パッケージ (`dependencies.apm`)**: Skills (SKILL.md バンドル) / commands / prompts / hooks 等を含む Claude Code プラグインを GitHub から取得する。このリポジトリでは `code-review`, `superpowers` を採用 → [`apm-plugins.instructions.md`](./apm-plugins.instructions.md)
+- **APM パッケージ (`dependencies.apm`)**: Skills / commands / prompts / hooks / instructions 等を含む APM プラグイン (またはその中の単一プリミティブファイル) を GitHub から取得する。このリポジトリでは `github/awesome-copilot/instructions/code-review-generic.instructions.md` (汎用コードレビュー指示) と `obra/superpowers` (汎用スキル群) を採用 → [`apm-plugins.instructions.md`](./apm-plugins.instructions.md)
 - **APM スキル (`--skill` フラグ)**: SKILL_BUNDLE から個別の SKILL.md を選択的にインストール
 
 MCP サーバー / APM パッケージ / APM スキル はそれぞれ独立したプリミティブなので、用語を混同しないこと。

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,157 +1,157 @@
-lockfile_version: '1'
-generated_at: '2026-05-23T12:25:00.616175+00:00'
+lockfile_version: "1"
+generated_at: "2026-05-23T13:47:47.203968+00:00"
 apm_version: 0.14.1
 dependencies:
-- repo_url: anthropics/claude-code
-  host: github.com
-  resolved_commit: 39e853e4074d90f27afdfb7ea601e0fc378bd0c5
-  resolved_ref: 39e853e4074d90f27afdfb7ea601e0fc378bd0c5
-  virtual_path: plugins/code-review
-  is_virtual: true
-  package_type: marketplace_plugin
-  deployed_files:
-  - .claude/commands/code-review.md
-  - .github/prompts/code-review.prompt.md
-  deployed_file_hashes:
-    .claude/commands/code-review.md: sha256:ecab79f22b6e2bef07a524d2015aaa9e0b7abce82445f38b31a231b19c7bd43a
-    .github/prompts/code-review.prompt.md: sha256:2b0837c5ec0b2e75f8ba4565bdafd76fa916b0dc146608c5733af7ba5802012c
-  content_hash: sha256:d25f797947bbd724551746c24ed4ac40788aaf370a7857eb120180fbb00ac2be
-- repo_url: obra/superpowers
-  host: github.com
-  resolved_commit: f2cbfbefebbfef77321e4c9abc9e949826bea9d7
-  resolved_ref: f2cbfbefebbfef77321e4c9abc9e949826bea9d7
-  package_type: marketplace_plugin
-  deployed_files:
-  - .agents/skills/brainstorming
-  - .agents/skills/dispatching-parallel-agents
-  - .agents/skills/executing-plans
-  - .agents/skills/finishing-a-development-branch
-  - .agents/skills/receiving-code-review
-  - .agents/skills/requesting-code-review
-  - .agents/skills/subagent-driven-development
-  - .agents/skills/systematic-debugging
-  - .agents/skills/test-driven-development
-  - .agents/skills/using-git-worktrees
-  - .agents/skills/using-superpowers
-  - .agents/skills/verification-before-completion
-  - .agents/skills/writing-plans
-  - .agents/skills/writing-skills
-  - .claude/hooks/superpowers/hooks/run-hook.cmd
-  - .claude/hooks/superpowers/hooks/run-hook.cmd
-  - .claude/skills/brainstorming
-  - .claude/skills/dispatching-parallel-agents
-  - .claude/skills/executing-plans
-  - .claude/skills/finishing-a-development-branch
-  - .claude/skills/receiving-code-review
-  - .claude/skills/requesting-code-review
-  - .claude/skills/subagent-driven-development
-  - .claude/skills/systematic-debugging
-  - .claude/skills/test-driven-development
-  - .claude/skills/using-git-worktrees
-  - .claude/skills/using-superpowers
-  - .claude/skills/verification-before-completion
-  - .claude/skills/writing-plans
-  - .claude/skills/writing-skills
-  - .codex/hooks/superpowers/hooks/run-hook.cmd
-  - .codex/hooks/superpowers/hooks/run-hook.cmd
-  - .github/hooks/scripts/superpowers/hooks/run-hook.cmd
-  - .github/hooks/scripts/superpowers/hooks/run-hook.cmd
-  - .github/hooks/superpowers-hooks-cursor.json
-  - .github/hooks/superpowers-hooks-cursor.json
-  - .github/hooks/superpowers-hooks.json
-  - .github/hooks/superpowers-hooks.json
-  deployed_file_hashes:
-    .claude/hooks/superpowers/hooks/run-hook.cmd: sha256:d3d9c6199678dab2858e60509dde5e7414f13c2a2b5e48a38b1d368b6e1d6abb
-    .codex/hooks/superpowers/hooks/run-hook.cmd: sha256:d3d9c6199678dab2858e60509dde5e7414f13c2a2b5e48a38b1d368b6e1d6abb
-    .github/hooks/scripts/superpowers/hooks/run-hook.cmd: sha256:d3d9c6199678dab2858e60509dde5e7414f13c2a2b5e48a38b1d368b6e1d6abb
-    .github/hooks/superpowers-hooks-cursor.json: sha256:53d8ceb3ff5d8bb1c4f283f238cc868b8c1af22e40a3ac30f6d6e4173effefbd
-    .github/hooks/superpowers-hooks.json: sha256:414b2cda93dfd4523ea183cc02c29b17b7c92bbfd54ad89acd83aadac042ea5a
-  content_hash: sha256:fb4f87bfef928a6d68f5d5aaa29e3eba011961c5f03bbf171c3c348d8d161abb
+  - repo_url: github/awesome-copilot
+    host: github.com
+    resolved_commit: 5b049e4e196c10aab8ddfd9e492323d08cf985b0
+    resolved_ref: 5b049e4e196c10aab8ddfd9e492323d08cf985b0
+    virtual_path: instructions/code-review-generic.instructions.md
+    is_virtual: true
+    package_type: apm_package
+    deployed_files:
+      - .claude/rules/code-review-generic.md
+      - .github/instructions/code-review-generic.instructions.md
+    deployed_file_hashes:
+      .claude/rules/code-review-generic.md: sha256:438a95faf5d7e0c1d52f0be55ca6d751a133a30f07cd95f09390803635267e5d
+      .github/instructions/code-review-generic.instructions.md: sha256:e6917309e3e986cde1650768cc871f54e5d054e90c4518afb5c937941ee212a9
+    content_hash: sha256:31212689590950d38ab751ad947ac94078ec57eb71a497c5b126135bc05dc7e1
+  - repo_url: obra/superpowers
+    host: github.com
+    resolved_commit: f2cbfbefebbfef77321e4c9abc9e949826bea9d7
+    resolved_ref: f2cbfbefebbfef77321e4c9abc9e949826bea9d7
+    package_type: marketplace_plugin
+    deployed_files:
+      - .agents/skills/brainstorming
+      - .agents/skills/dispatching-parallel-agents
+      - .agents/skills/executing-plans
+      - .agents/skills/finishing-a-development-branch
+      - .agents/skills/receiving-code-review
+      - .agents/skills/requesting-code-review
+      - .agents/skills/subagent-driven-development
+      - .agents/skills/systematic-debugging
+      - .agents/skills/test-driven-development
+      - .agents/skills/using-git-worktrees
+      - .agents/skills/using-superpowers
+      - .agents/skills/verification-before-completion
+      - .agents/skills/writing-plans
+      - .agents/skills/writing-skills
+      - .claude/hooks/superpowers/hooks/run-hook.cmd
+      - .claude/hooks/superpowers/hooks/run-hook.cmd
+      - .claude/skills/brainstorming
+      - .claude/skills/dispatching-parallel-agents
+      - .claude/skills/executing-plans
+      - .claude/skills/finishing-a-development-branch
+      - .claude/skills/receiving-code-review
+      - .claude/skills/requesting-code-review
+      - .claude/skills/subagent-driven-development
+      - .claude/skills/systematic-debugging
+      - .claude/skills/test-driven-development
+      - .claude/skills/using-git-worktrees
+      - .claude/skills/using-superpowers
+      - .claude/skills/verification-before-completion
+      - .claude/skills/writing-plans
+      - .claude/skills/writing-skills
+      - .codex/hooks/superpowers/hooks/run-hook.cmd
+      - .codex/hooks/superpowers/hooks/run-hook.cmd
+      - .github/hooks/scripts/superpowers/hooks/run-hook.cmd
+      - .github/hooks/scripts/superpowers/hooks/run-hook.cmd
+      - .github/hooks/superpowers-hooks-cursor.json
+      - .github/hooks/superpowers-hooks-cursor.json
+      - .github/hooks/superpowers-hooks.json
+      - .github/hooks/superpowers-hooks.json
+    deployed_file_hashes:
+      .claude/hooks/superpowers/hooks/run-hook.cmd: sha256:d3d9c6199678dab2858e60509dde5e7414f13c2a2b5e48a38b1d368b6e1d6abb
+      .codex/hooks/superpowers/hooks/run-hook.cmd: sha256:d3d9c6199678dab2858e60509dde5e7414f13c2a2b5e48a38b1d368b6e1d6abb
+      .github/hooks/scripts/superpowers/hooks/run-hook.cmd: sha256:d3d9c6199678dab2858e60509dde5e7414f13c2a2b5e48a38b1d368b6e1d6abb
+      .github/hooks/superpowers-hooks-cursor.json: sha256:53d8ceb3ff5d8bb1c4f283f238cc868b8c1af22e40a3ac30f6d6e4173effefbd
+      .github/hooks/superpowers-hooks.json: sha256:414b2cda93dfd4523ea183cc02c29b17b7c92bbfd54ad89acd83aadac042ea5a
+    content_hash: sha256:fb4f87bfef928a6d68f5d5aaa29e3eba011961c5f03bbf171c3c348d8d161abb
 mcp_servers:
-- chrome-devtools
-- context7
-- semgrep
-- serena
+  - chrome-devtools
+  - context7
+  - semgrep
+  - serena
 mcp_configs:
   chrome-devtools:
     name: chrome-devtools
     transport: stdio
     args:
-    - -y
-    - chrome-devtools-mcp@1.0.1
+      - -y
+      - chrome-devtools-mcp@1.0.1
     registry: false
     command: npx
   context7:
     name: context7
     transport: stdio
     args:
-    - -y
-    - '@upstash/context7-mcp'
+      - -y
+      - "@upstash/context7-mcp"
     registry: false
     command: npx
   semgrep:
     name: semgrep
     transport: stdio
     args:
-    - semgrep-mcp
+      - semgrep-mcp
     registry: false
     command: uvx
   serena:
     name: serena
     transport: stdio
     args:
-    - --from
-    - git+https://github.com/oraios/serena@c3a8d5a9c54622c8ce771a54e5feffd6efda8749
-    - serena
-    - start-mcp-server
+      - --from
+      - git+https://github.com/oraios/serena@c3a8d5a9c54622c8ce771a54e5feffd6efda8749
+      - serena
+      - start-mcp-server
     registry: false
     command: uvx
 local_deployed_files:
-- .claude/rules/apm-plugins.md
-- .claude/rules/apm-workflow.md
-- .claude/rules/dev-workflow.md
-- .claude/rules/feature-spec.md
-- .claude/rules/github-ops.md
-- .claude/rules/lint.md
-- .claude/rules/local-dev-workflow.md
-- .claude/rules/mcp-servers.md
-- .claude/rules/pr-review.md
-- .claude/rules/setup.md
-- .claude/rules/styling.md
-- .claude/rules/typescript.md
-- .github/instructions/apm-plugins.instructions.md
-- .github/instructions/apm-workflow.instructions.md
-- .github/instructions/dev-workflow.instructions.md
-- .github/instructions/feature-spec.instructions.md
-- .github/instructions/github-ops.instructions.md
-- .github/instructions/lint.instructions.md
-- .github/instructions/local-dev-workflow.instructions.md
-- .github/instructions/mcp-servers.instructions.md
-- .github/instructions/pr-review.instructions.md
-- .github/instructions/setup.instructions.md
-- .github/instructions/styling.instructions.md
-- .github/instructions/typescript.instructions.md
+  - .claude/rules/apm-plugins.md
+  - .claude/rules/apm-workflow.md
+  - .claude/rules/dev-workflow.md
+  - .claude/rules/feature-spec.md
+  - .claude/rules/github-ops.md
+  - .claude/rules/lint.md
+  - .claude/rules/local-dev-workflow.md
+  - .claude/rules/mcp-servers.md
+  - .claude/rules/pr-review.md
+  - .claude/rules/setup.md
+  - .claude/rules/styling.md
+  - .claude/rules/typescript.md
+  - .github/instructions/apm-plugins.instructions.md
+  - .github/instructions/apm-workflow.instructions.md
+  - .github/instructions/dev-workflow.instructions.md
+  - .github/instructions/feature-spec.instructions.md
+  - .github/instructions/github-ops.instructions.md
+  - .github/instructions/lint.instructions.md
+  - .github/instructions/local-dev-workflow.instructions.md
+  - .github/instructions/mcp-servers.instructions.md
+  - .github/instructions/pr-review.instructions.md
+  - .github/instructions/setup.instructions.md
+  - .github/instructions/styling.instructions.md
+  - .github/instructions/typescript.instructions.md
 local_deployed_file_hashes:
-  .claude/rules/apm-plugins.md: sha256:9118bec09212e9b229ea85d723be645e7f8ed4423f50a3a32008eb74f87aa7da
+  .claude/rules/apm-plugins.md: sha256:91876db4e37cf245f48cc5aaa4336a2a614edd6f4529c4d4b0ea41582e254b50
   .claude/rules/apm-workflow.md: sha256:d44ceeb955c105f7eedb42caf13c6c7b6d2ef8a894e25b528cd07d11eb59a464
   .claude/rules/dev-workflow.md: sha256:575e7177d9f2ae512439ca8eb67b136cef2bf08668d0194df8aa71448386b02a
   .claude/rules/feature-spec.md: sha256:587be25e9fdf17d27c6d0f5baa92485ecb289d4c8a6eb41b7acbe3e76ce64eb8
   .claude/rules/github-ops.md: sha256:8a273f3d7c9ea772e0d46da9327955da273da6423d2de0d53e552ed325dded1e
   .claude/rules/lint.md: sha256:1ff76e33314db0b04a26b13e3a7e61830f406485ad1da7607dc8b2c655c300d9
   .claude/rules/local-dev-workflow.md: sha256:974bd5a144ee20a5e740a83e2f9b8b76f2d3b435a6dd3bd393a9ccc4a2f66562
-  .claude/rules/mcp-servers.md: sha256:e62306fd88efa432f1cb318024f2b071771f1e0cdd4ef8c909695adc12238489
+  .claude/rules/mcp-servers.md: sha256:3b6cd105d03954f1a114bddc9e322d7b4ec029c011264e536324c6c3640cad27
   .claude/rules/pr-review.md: sha256:799fc994a20d1ed30efc553da63afbd668956da71d2d0b1bddb7aefb633e8e3a
   .claude/rules/setup.md: sha256:c7c656c7dd63047cbdbf364cece24292241aadac8ee61fdbb0e287aafec1b6f8
   .claude/rules/styling.md: sha256:f35e25e78afd7a4b65c19104c999e55fbff12112ec4cba10abe55d3d05b36fce
   .claude/rules/typescript.md: sha256:6bf8ab3e30dc8184bf63622a9d03c084d17de76aac984fef29a98a6c9defe2d5
-  .github/instructions/apm-plugins.instructions.md: sha256:5d28e0fa926ad4b43363793ff121ffd0070b78769d940f5b4c7addf4d89cf0cb
+  .github/instructions/apm-plugins.instructions.md: sha256:4c9d4ba25f6d738f31272c2edf3fc922e4fd6a62c5a727a4bffc503173b4c60c
   .github/instructions/apm-workflow.instructions.md: sha256:376dc062de13a9ff4994e69569ecd77e4f86839ffd2961d9840fff538dbcbd2e
   .github/instructions/dev-workflow.instructions.md: sha256:1985ead9e21a9af851c1c8e9bf2039f30d7c70f77299716854aadd604c8c201d
   .github/instructions/feature-spec.instructions.md: sha256:d641da9a56e032cef5b7d8d29a0cc2a472723b9848a5906bd02f1bf211165e07
   .github/instructions/github-ops.instructions.md: sha256:618e6525ce967083cf32c25deca4c6255dd78465981b345588a323789d4dcf50
   .github/instructions/lint.instructions.md: sha256:e4d1c252de1773dfe9aa7d7fa2a4f63e6ee9f07fa04cebabca3ff9a1ad72da1a
   .github/instructions/local-dev-workflow.instructions.md: sha256:d85f1a5b6a133f246ab3e7043ed3932052c1defb5ad77017019c11d0b3f05e2d
-  .github/instructions/mcp-servers.instructions.md: sha256:c1cd3bb45a01839236874addad963a99374bc8d13d045fc3e03e99de6211376f
+  .github/instructions/mcp-servers.instructions.md: sha256:090a6963c3c460d336e829c48c49c527e53b31df85a3367ab544f4ac92c3dd88
   .github/instructions/pr-review.instructions.md: sha256:d785037a0bfc858b8b6711bd9b17c01f0213a7b3c07959cd13dec253004acacd
   .github/instructions/setup.instructions.md: sha256:5719277129c59f6cfd948150655583a11118140df0325727c44e2c5cf9e0195d
   .github/instructions/styling.instructions.md: sha256:cfb5373ec78a677e02ba28c87774ac78a172790aae88eae3b23dd7837398d9b1

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: "1"
-generated_at: "2026-05-23T13:47:47.203968+00:00"
+generated_at: "2026-05-24T00:46:46.315739+00:00"
 apm_version: 0.14.1
 dependencies:
   - repo_url: github/awesome-copilot
@@ -37,7 +37,6 @@ dependencies:
       - .agents/skills/writing-plans
       - .agents/skills/writing-skills
       - .claude/hooks/superpowers/hooks/run-hook.cmd
-      - .claude/hooks/superpowers/hooks/run-hook.cmd
       - .claude/skills/brainstorming
       - .claude/skills/dispatching-parallel-agents
       - .claude/skills/executing-plans
@@ -53,12 +52,8 @@ dependencies:
       - .claude/skills/writing-plans
       - .claude/skills/writing-skills
       - .codex/hooks/superpowers/hooks/run-hook.cmd
-      - .codex/hooks/superpowers/hooks/run-hook.cmd
-      - .github/hooks/scripts/superpowers/hooks/run-hook.cmd
       - .github/hooks/scripts/superpowers/hooks/run-hook.cmd
       - .github/hooks/superpowers-hooks-cursor.json
-      - .github/hooks/superpowers-hooks-cursor.json
-      - .github/hooks/superpowers-hooks.json
       - .github/hooks/superpowers-hooks.json
     deployed_file_hashes:
       .claude/hooks/superpowers/hooks/run-hook.cmd: sha256:d3d9c6199678dab2858e60509dde5e7414f13c2a2b5e48a38b1d368b6e1d6abb
@@ -132,26 +127,26 @@ local_deployed_files:
   - .github/instructions/styling.instructions.md
   - .github/instructions/typescript.instructions.md
 local_deployed_file_hashes:
-  .claude/rules/apm-plugins.md: sha256:91876db4e37cf245f48cc5aaa4336a2a614edd6f4529c4d4b0ea41582e254b50
-  .claude/rules/apm-workflow.md: sha256:d44ceeb955c105f7eedb42caf13c6c7b6d2ef8a894e25b528cd07d11eb59a464
+  .claude/rules/apm-plugins.md: sha256:414c95c3da43dcb9304215d53e69c27bd88204911207f17816591abc5d3735fb
+  .claude/rules/apm-workflow.md: sha256:64270fe9ab168863a48be6b6e84d5778343b86ec6859f89c7a3d8372d8a451a1
   .claude/rules/dev-workflow.md: sha256:575e7177d9f2ae512439ca8eb67b136cef2bf08668d0194df8aa71448386b02a
   .claude/rules/feature-spec.md: sha256:587be25e9fdf17d27c6d0f5baa92485ecb289d4c8a6eb41b7acbe3e76ce64eb8
   .claude/rules/github-ops.md: sha256:8a273f3d7c9ea772e0d46da9327955da273da6423d2de0d53e552ed325dded1e
   .claude/rules/lint.md: sha256:1ff76e33314db0b04a26b13e3a7e61830f406485ad1da7607dc8b2c655c300d9
   .claude/rules/local-dev-workflow.md: sha256:974bd5a144ee20a5e740a83e2f9b8b76f2d3b435a6dd3bd393a9ccc4a2f66562
-  .claude/rules/mcp-servers.md: sha256:3b6cd105d03954f1a114bddc9e322d7b4ec029c011264e536324c6c3640cad27
+  .claude/rules/mcp-servers.md: sha256:caa72b9d598ce87acc3230c3bbd656a431f466fdf95a299928c49b101df17c4c
   .claude/rules/pr-review.md: sha256:799fc994a20d1ed30efc553da63afbd668956da71d2d0b1bddb7aefb633e8e3a
   .claude/rules/setup.md: sha256:c7c656c7dd63047cbdbf364cece24292241aadac8ee61fdbb0e287aafec1b6f8
   .claude/rules/styling.md: sha256:f35e25e78afd7a4b65c19104c999e55fbff12112ec4cba10abe55d3d05b36fce
   .claude/rules/typescript.md: sha256:6bf8ab3e30dc8184bf63622a9d03c084d17de76aac984fef29a98a6c9defe2d5
-  .github/instructions/apm-plugins.instructions.md: sha256:4c9d4ba25f6d738f31272c2edf3fc922e4fd6a62c5a727a4bffc503173b4c60c
-  .github/instructions/apm-workflow.instructions.md: sha256:376dc062de13a9ff4994e69569ecd77e4f86839ffd2961d9840fff538dbcbd2e
+  .github/instructions/apm-plugins.instructions.md: sha256:961199f132eed0be38c6a89990f3e9b54fc0bf02e5ccba29b1770d6e71ba304c
+  .github/instructions/apm-workflow.instructions.md: sha256:db2207c61eadd77ae5f395e062c48a7824f2159d42efecc195685c785c676105
   .github/instructions/dev-workflow.instructions.md: sha256:1985ead9e21a9af851c1c8e9bf2039f30d7c70f77299716854aadd604c8c201d
   .github/instructions/feature-spec.instructions.md: sha256:d641da9a56e032cef5b7d8d29a0cc2a472723b9848a5906bd02f1bf211165e07
   .github/instructions/github-ops.instructions.md: sha256:618e6525ce967083cf32c25deca4c6255dd78465981b345588a323789d4dcf50
   .github/instructions/lint.instructions.md: sha256:e4d1c252de1773dfe9aa7d7fa2a4f63e6ee9f07fa04cebabca3ff9a1ad72da1a
   .github/instructions/local-dev-workflow.instructions.md: sha256:d85f1a5b6a133f246ab3e7043ed3932052c1defb5ad77017019c11d0b3f05e2d
-  .github/instructions/mcp-servers.instructions.md: sha256:090a6963c3c460d336e829c48c49c527e53b31df85a3367ab544f4ac92c3dd88
+  .github/instructions/mcp-servers.instructions.md: sha256:503f75234d7f564676f77c4ec19c1c43a0b94ee635d5a65a518b742c98b63e2e
   .github/instructions/pr-review.instructions.md: sha256:d785037a0bfc858b8b6711bd9b17c01f0213a7b3c07959cd13dec253004acacd
   .github/instructions/setup.instructions.md: sha256:5719277129c59f6cfd948150655583a11118140df0325727c44e2c5cf9e0195d
   .github/instructions/styling.instructions.md: sha256:cfb5373ec78a677e02ba28c87774ac78a172790aae88eae3b23dd7837398d9b1

--- a/apm.yml
+++ b/apm.yml
@@ -1,45 +1,45 @@
 name: bingo-machine
-version: 1.6.5
+version: 2.0.0
 description: AI agent instructions for the Bingo Machine project
 author: ROhta
 license: GPL-3.0-or-later
 type: instructions
 targets:
-- claude
-- codex
-- copilot
+  - claude
+  - codex
+  - copilot
 includes: auto
 dependencies:
   mcp:
-  - name: semgrep
-    registry: false
-    transport: stdio
-    command: uvx
-    args:
-    - semgrep-mcp
-  - name: chrome-devtools
-    registry: false
-    transport: stdio
-    command: npx
-    args:
-    - -y
-    - chrome-devtools-mcp@1.0.1
-  - name: serena
-    registry: false
-    transport: stdio
-    command: uvx
-    args:
-    - --from
-    - git+https://github.com/oraios/serena@c3a8d5a9c54622c8ce771a54e5feffd6efda8749
-    - serena
-    - start-mcp-server
-  - name: context7
-    registry: false
-    transport: stdio
-    command: npx
-    args:
-    - -y
-    - '@upstash/context7-mcp'
+    - name: semgrep
+      registry: false
+      transport: stdio
+      command: uvx
+      args:
+        - semgrep-mcp
+    - name: chrome-devtools
+      registry: false
+      transport: stdio
+      command: npx
+      args:
+        - -y
+        - chrome-devtools-mcp@1.0.1
+    - name: serena
+      registry: false
+      transport: stdio
+      command: uvx
+      args:
+        - --from
+        - git+https://github.com/oraios/serena@c3a8d5a9c54622c8ce771a54e5feffd6efda8749
+        - serena
+        - start-mcp-server
+    - name: context7
+      registry: false
+      transport: stdio
+      command: npx
+      args:
+        - -y
+        - "@upstash/context7-mcp"
   apm:
-  - anthropics/claude-code/plugins/code-review#39e853e4074d90f27afdfb7ea601e0fc378bd0c5
-  - obra/superpowers#f2cbfbefebbfef77321e4c9abc9e949826bea9d7
+    - github/awesome-copilot/instructions/code-review-generic.instructions.md#5b049e4e196c10aab8ddfd9e492323d08cf985b0
+    - obra/superpowers#f2cbfbefebbfef77321e4c9abc9e949826bea9d7

--- a/apm.yml
+++ b/apm.yml
@@ -1,5 +1,5 @@
 name: bingo-machine
-version: 2.0.0
+version: 2.0.1
 description: AI agent instructions for the Bingo Machine project
 author: ROhta
 license: GPL-3.0-or-later

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,4 +24,14 @@ export default tseslint.config(
 			},
 		},
 	},
+	{
+		files: ["scripts/**/*.mjs"],
+		languageOptions: {
+			ecmaVersion: 2022,
+			sourceType: "module",
+			globals: {
+				...globals.node,
+			},
+		},
+	},
 )

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"watch": "pnpm exec tsc -b -w",
 		"clean": "pnpm exec tsc -b --clean",
 		"serve": "pnpm exec http-server -p 62800 -o src/index.html -s",
-		"prepare": "husky"
+		"prepare": "husky",
+		"apm-install": "apm install && node scripts/dedupe-apm-lock.mjs"
 	},
 	"engines": {
 		"node": ">=24.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bingo-machine",
-	"version": "1.6.5",
+	"version": "2.0.1",
 	"author": "ROhta",
 	"description": "A Bingo Machine for Party",
 	"private": false,

--- a/scripts/dedupe-apm-lock.mjs
+++ b/scripts/dedupe-apm-lock.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// APM CLI v0.14.1 が apm.lock.yaml の `deployed_files:` 配列に同一パスを
+// 2 回ずつ出力する問題に対する post-process。隣接した同一の `- <value>`
+// 行を 1 行に畳む (YAML パーサ非依存)。
+import {readFileSync, writeFileSync} from "node:fs"
+
+const PATH = "apm.lock.yaml"
+const original = readFileSync(PATH, "utf-8")
+
+let deduped = original
+let prev
+do {
+	prev = deduped
+	deduped = deduped.replace(/^([ \t]*-[ \t]+.+)$\n\1$/gm, "$1")
+} while (deduped !== prev)
+
+if (deduped === original) {
+	console.log(`${PATH}: no adjacent duplicate array entries found.`)
+	process.exit(0)
+}
+
+writeFileSync(PATH, deduped)
+const removed = original.split("\n").length - deduped.split("\n").length
+console.log(`${PATH}: removed ${removed} duplicate line(s).`)


### PR DESCRIPTION
## Summary

- `dependencies.apm` の `anthropics/claude-code/plugins/code-review` を `github/awesome-copilot/instructions/code-review-generic.instructions.md#5b049e4` に差し替え。AI ベンダー組織配下リポジトリへの依存を排除し、GitHub コミュニティ curated marketplace の vendor-neutral プリミティブを採用。
- これまで Anthropic 提供版が **Codex には何も配信しておらず** (`.codex/` 配下にファイル無し) Codex で `/code-review` が使えなかった点を、`apm compile` 経由で `AGENTS.md` に instructions を組み込む方式に切り替えることで解消。Claude / Copilot / Codex の 3 ターゲット全てに同等のコードレビュー指示が届くようになる。
- `package.json` と `apm.yml` の `version` を `2.0.1` に揃える (これまで両者とも `1.6.5` で APM 導入時のまま放置されていた)。今回の差し替えは UI / コードベースに影響しないため、本日リリースした v2.0.0 に対する patch 採番。
- `.apm/instructions/apm-plugins.instructions.md` / `mcp-servers.instructions.md` のドキュメント表・参照先・install コマンド例を更新し、vendor-neutral 方針と APM の virtual file 構文 (`<owner>/<repo>/<file>.instructions.md#<sha>`) の説明を追記。

## Why

Codex 含む全ターゲットで一貫した AI エージェント体験を提供するため、特定 AI ベンダー (Anthropic) 組織のプラグインに依存している箇所を取り除く。Anthropic の `plugins/code-review` は Claude Code の Stop hook + subagent runtime 前提で書かれており、Copilot 向けには静的プロンプトを流用しているだけ、Codex には何も配信しないという非対称があった。

## Test plan

- [x] `apm install` がエラーなく完走し、`apm.lock.yaml` が新依存で再生成されることを確認
- [x] `apm compile` 後の `AGENTS.md` (Codex 用) に `code-review-generic` 内容が組み込まれることを確認
- [x] `.claude/rules/code-review-generic.md` および `.github/instructions/code-review-generic.instructions.md` が生成されることを確認
- [ ] CI (pages-build / dependency-review 等) が green
- [ ] Copilot Code Review がこの PR に対し `code-review-generic` 指示に従ったレビューを行うか観察