### PR TITLE
リリースノート手順を補強 (ラベル付与必須化 + ヘッダ 変更点 正規化)

### DIFF
--- a/.apm/instructions/dev-workflow.instructions.md
+++ b/.apm/instructions/dev-workflow.instructions.md
@@ -24,32 +24,37 @@ applyTo: "**"
    - heredoc で annotation を `-F -` (stdin) に渡してコマンド実行:
 
      ```bash
-     git tag -s -a v*.*.* -F - <<'EOF'
+     # 今回打つタグを変数に束ねる (シェル glob 展開回避 + 全コマンドで同一値参照)
+     TAG=v2.0.2   # 例。実際の値に置き換える
+
+     git tag -s -a "$TAG" -F - <<'EOF'
      メジャー・マイナー・パッチバージョンアップの理由
 
      - <バージョンアップ理由>
      EOF
-     git push origin v*.*.*
+     git push origin "$TAG"
      ```
 
 8. 自動生成機能を用いてリリースノート作成 → ヘッダ表記を `変更点` に揃える
 
    ```bash
    # 8-1. release を作成 (notes は --generate-notes で auto-generate)
-   gh release create v*.*.* --title 'v*.*.*' --generate-notes --latest --verify-tag
+   gh release create "$TAG" --title "$TAG" --generate-notes --latest --verify-tag
 
    # 8-2. デフォルトヘッダ "What's Changed" を "変更点" に置換
    #      (GitHub の release.yml は header field の上書きを公式サポートしないため自前で sed)
-   gh release view v*.*.* --json body --jq '.body' \
+   gh release view "$TAG" --json body --jq '.body' \
      | sed 's/^## What.s Changed$/## 変更点/' > /tmp/release-notes.md
-   gh release edit v*.*.* --notes-file /tmp/release-notes.md
+   gh release edit "$TAG" --notes-file /tmp/release-notes.md
    ```
 
    ラベル未付与の PR がリリースに出なかったことに後で気付いた場合は、PR にラベルを付けてから以下で再生成可能:
 
    ```bash
-   gh api repos/<owner>/<repo>/releases/generate-notes -X POST \
-     -f tag_name=v*.*.* -f previous_tag_name=v<prev>.<prev>.<prev> \
+   PREV_TAG=v2.0.1   # 例。直前リリースのタグに置き換える
+
+   gh api "repos/$(gh repo view --json nameWithOwner --jq .nameWithOwner)/releases/generate-notes" -X POST \
+     -f "tag_name=$TAG" -f "previous_tag_name=$PREV_TAG" \
      --jq '.body' | sed 's/^## What.s Changed$/## 変更点/' > /tmp/release-notes.md
-   gh release edit v*.*.* --notes-file /tmp/release-notes.md
+   gh release edit "$TAG" --notes-file /tmp/release-notes.md
    ```

--- a/.apm/instructions/dev-workflow.instructions.md
+++ b/.apm/instructions/dev-workflow.instructions.md
@@ -10,6 +10,8 @@ applyTo: "**"
 1. ブランチ作成
 2. 開発
 3. PR 作成
+   - **必ず `.github/release.yml` の `changelog.categories` に対応するラベルを付与** (例: `bug-3 改善`, `enhance-2 新機能`, `enhance-1 破壊的変更`, `bug-1 重大バグ`, `bug-2 バグ`, `enhance-3 ドキュメント`, `dependencies`, `refactor`)
+   - ラベル未付与の PR はリリースノートに出てこない (GitHub auto-generated changelog の挙動)
 4. PR レビュー
 5. PR マージ
 6. 自動デプロイ
@@ -27,6 +29,27 @@ applyTo: "**"
 
      - <バージョンアップ理由>
      EOF
+     git push origin v*.*.*
      ```
 
-8. 自動生成機能を用いて、リリースノート作成
+8. 自動生成機能を用いてリリースノート作成 → ヘッダ表記を `変更点` に揃える
+
+   ```bash
+   # 8-1. release を作成 (notes は --generate-notes で auto-generate)
+   gh release create v*.*.* --title 'v*.*.*' --generate-notes --latest --verify-tag
+
+   # 8-2. デフォルトヘッダ "What's Changed" を "変更点" に置換
+   #      (GitHub の release.yml は header field の上書きを公式サポートしないため自前で sed)
+   gh release view v*.*.* --json body --jq '.body' \
+     | sed 's/^## What.s Changed$/## 変更点/' > /tmp/release-notes.md
+   gh release edit v*.*.* --notes-file /tmp/release-notes.md
+   ```
+
+   ラベル未付与の PR がリリースに出なかったことに後で気付いた場合は、PR にラベルを付けてから以下で再生成可能:
+
+   ```bash
+   gh api repos/<owner>/<repo>/releases/generate-notes -X POST \
+     -f tag_name=v*.*.* -f previous_tag_name=v<prev>.<prev>.<prev> \
+     --jq '.body' | sed 's/^## What.s Changed$/## 変更点/' > /tmp/release-notes.md
+   gh release edit v*.*.* --notes-file /tmp/release-notes.md
+   ```


### PR DESCRIPTION
## 変更点

v2.0.0 / v2.0.1 のリリース作業で 2 件の事後対応が必要だった経験を、`.apm/instructions/dev-workflow.instructions.md` に明文化する。

### 1. PR ラベル付与の必須化 (開発者向け step 3)

\`.github/release.yml\` の \`changelog.categories\` に対応するラベル (`bug-3 改善`, `enhance-2 新機能`, `enhance-1 破壊的変更`, `bug-1 重大バグ`, `bug-2 バグ`, `enhance-3 ドキュメント`, `dependencies`, `refactor`) が付いていない PR は GitHub auto-generated changelog から除外されるため、リリースノートに出てこない。v2.0.0 では 26 PR 中 9 件が未ラベルで欠落、v2.0.1 でも PR #379 が同様に欠落していた。

### 2. ヘッダ "What's Changed" の正規化 (管理者向け step 8)

GitHub の \`release.yml\` は \`changelog.header\` 相当のフィールドを公式サポートしておらず、`gh release create --generate-notes` および \`POST /releases/generate-notes\` はデフォルトで \`## What's Changed\` を返す。本リポジトリのリリース慣例 \`## 変更点\` に合わせるため、release 作成後に \`sed\` で置換するワンライナーを手順に組み込む。

```bash
gh release view v*.*.* --json body --jq '.body' \
  | sed 's/^## What.s Changed$/## 変更点/' > /tmp/release-notes.md
gh release edit v*.*.* --notes-file /tmp/release-notes.md
```

### 3. その他

- 管理者向け step 7 に \`git push origin v*.*.*\` の例を明記
- ラベル付与漏れに事後で気付いた場合の再生成手順 (POST /releases/generate-notes + gh release edit) も併記

## Why

リリースのたびに同じ事後修正を繰り返すのを止め、手順書を Source of Truth にする。AI エージェントもこの手順書を参照するため、`.apm/instructions/` 配下に置くことで自動的に \`.github/instructions/\`, \`.claude/rules/\`, \`AGENTS.md\` 等へ配信される。

## Test plan

- [ ] CI green
- [ ] 次回リリース時に本手順書通りで完結することを確認 (このリポジトリでの実運用検証)