### PR TITLE
mise で node/pnpm/apm のバージョンを SSoT 管理 (設計)

### DIFF
--- a/.apm/instructions/apm-workflow.instructions.md
+++ b/.apm/instructions/apm-workflow.instructions.md
@@ -9,6 +9,10 @@ applyTo: ".apm/**"
 
 `.apm/instructions/*.instructions.md` がすべての AI エージェント向け指示の Source of Truth。ここを編集することで、Claude Code / Codex CLI / GitHub Copilot すべてに同じ指示が届く。
 
+## APM CLI 本体のバージョン
+
+APM CLI 本体 (`apm` バイナリ) のバージョンは `mise.toml` (`github:microsoft/apm`) を SSoT として管理する。更新は `mise.toml` の version を上げて `mise install` する。`apm self-update` や `apm doctor` の更新催促には従わない (mise 管理外のグローバルインストールを増やさないため)。導入手順は [`setup.instructions.md`](./setup.instructions.md) を参照。
+
 ## ファイルの管理方針
 
 | パス                                                                                                                                                                                 | 役割                                                                              | リポジトリ追跡 |

--- a/.apm/instructions/github-ops.instructions.md
+++ b/.apm/instructions/github-ops.instructions.md
@@ -13,6 +13,10 @@ applyTo: ".github/**"
 - 放置 Issue/PR の自動削除
 - CodeQL で脆弱性を含むコードの検出 (TypeScript のみ)
 
+### ツールチェーン (node / pnpm)
+
+CI の node / pnpm は `mise.toml` を SSoT とし、`jdx/mise-action` (コミット SHA ピン・mise 本体は `version: 2026.6.1`) で導入する (`install_args: "node pnpm"` で対象を限定)。apm は CI では使用しないため導入しない。バージョン管理方針の詳細は [`setup.instructions.md`](./setup.instructions.md) を参照。
+
 ## セキュリティ対策
 
 - [Security Policy](https://github.com/ROhta/bingo/security/policy) を参照

--- a/.apm/instructions/setup.instructions.md
+++ b/.apm/instructions/setup.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: Bingo Machine の本番環境とローカル環境構築手順
-applyTo: "**/{package.json,pnpm-lock.yaml,tsconfig.json}"
+applyTo: "**/{mise.toml,package.json,pnpm-lock.yaml,tsconfig.json}"
 ---
 
 # 環境構築
@@ -11,7 +11,13 @@ applyTo: "**/{package.json,pnpm-lock.yaml,tsconfig.json}"
 
 ## ローカル環境構築
 
+- [mise](https://mise.jdx.dev/) (>= 2026.6.1) を導入する (node / pnpm / apm のバージョン管理に使用)
+  - Linux ホストでは、pnpm (Node SEA バイナリ) が `libatomic.so.1` を要求するため `libatomic1` を導入しておく (例: `sudo apt-get install -y libatomic1`)。GitHub Actions の `ubuntu-latest` 等には標準装備のため CI では不要。
 - `git clone`
-- node と pnpm を `package.json` で指定されたバージョンに設定
+- `mise trust && mise install` で `mise.toml` に固定された node / pnpm / apm を導入する
 - `pnpm i --frozen-lockfile`
 - `pnpm run dev`
+
+## バージョン管理 (mise)
+
+node / pnpm / apm CLI 本体のバージョンは `mise.toml` を唯一の真実源 (SSoT) とする。バージョンを上げる際は `mise.toml` を編集して `mise install` する (apm の `apm self-update` や `apm doctor` の更新催促には従わない)。CI も `jdx/mise-action` (mise 本体は `version: 2026.6.1` にピン) 経由で同じ `mise.toml` を消費する。mise 本体は最低 2026.6.1 を要する (これ未満では pnpm 11.5.2 の aqua アセット解決に失敗する)。

--- a/.apm/instructions/setup.instructions.md
+++ b/.apm/instructions/setup.instructions.md
@@ -15,8 +15,9 @@ applyTo: "**/{mise.toml,package.json,pnpm-lock.yaml,tsconfig.json}"
   - Linux ホストでは、pnpm (Node SEA バイナリ) が `libatomic.so.1` を要求するため `libatomic1` を導入しておく (例: `sudo apt-get install -y libatomic1`)。GitHub Actions の `ubuntu-latest` 等には標準装備のため CI では不要。
 - `git clone`
 - `mise trust && mise install` で `mise.toml` に固定された node / pnpm / apm を導入する
-- `pnpm i --frozen-lockfile`
-- `pnpm run dev`
+  - 以降の `pnpm` / `node` が mise 管理版を指すよう、シェルに mise を有効化しておく (`mise activate` を shell rc に追加し shims を PATH へ。導入方法は[公式手順](https://mise.jdx.dev/getting-started.html)参照)。有効化しない場合は各コマンドを `mise exec -- <cmd>` で実行する。
+- `pnpm i --frozen-lockfile` (mise 未有効化時は `mise exec -- pnpm i --frozen-lockfile`)
+- `pnpm run dev` (同上)
 
 ## バージョン管理 (mise)
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,9 +19,6 @@ jobs:
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
   Build-Check:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [24.16.0]
     timeout-minutes: 3
     permissions: {}
     steps:
@@ -30,13 +27,12 @@ jobs:
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      # node / pnpm のバージョンは mise.toml を SSoT とする。apm は CI で不要なので install 対象外。
+      # mise 本体の版は pnpm の aqua アセット解決に影響する実績があるため version をピンする。
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          node-version: ${{ matrix.node-version }}
-          check-latest: true
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: 11.1.2
+          version: 2026.6.1
+          install_args: "node pnpm"
       - name: Install Dependencies
         run: pnpm i --frozen-lockfile
       - name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,9 +27,6 @@ concurrency:
 jobs:
   Build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [24.16.0]
     timeout-minutes: 5
     permissions: {}
     steps:
@@ -44,13 +41,12 @@ jobs:
         run: |
           set -x
           docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint:1.7.4
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      # node / pnpm のバージョンは mise.toml を SSoT とする。apm は CI で不要なので install 対象外。
+      # mise 本体の版は pnpm の aqua アセット解決に影響する実績があるため version をピンする。
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          node-version: ${{ matrix.node-version }}
-          check-latest: true
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: 11.1.2
+          version: 2026.6.1
+          install_args: "node pnpm"
       - name: Install Dependencies
         run: pnpm i --frozen-lockfile
       - name: Build

--- a/docs/superpowers/plans/2026-06-09-mise-version-management.md
+++ b/docs/superpowers/plans/2026-06-09-mise-version-management.md
@@ -4,7 +4,7 @@
 
 **Goal:** `mise.toml` を node / pnpm / apm のバージョン情報の唯一の真実源 (SSoT) とし、`package.json` の `engines` を撤去、ローカルと CI を mise ベースに統一する。
 
-**Architecture:** リポジトリ直下の `mise.toml` に node/pnpm/apm を exact ピン。ローカルは `mise install`、CI は `jdx/mise-action` (SHA ピン) で同じ `mise.toml` を消費する。apm は mise の `github` バックエンドで microsoft/apm の Release を取得 (PyInstaller onedir を `extract_all` で展開、`exe` で起動エントリ指定)。
+**Architecture:** リポジトリ直下の `mise.toml` に node/pnpm/apm を exact ピン。ローカルは `mise install`、CI は `jdx/mise-action` (SHA ピン) で同じ `mise.toml` を消費する。apm は mise の `github` バックエンドで microsoft/apm の Release を取得 (PyInstaller onedir を `extract_all` で展開し、install root から bin を解決する。`exe` は指定しない — Task 1 補足2 参照)。
 
 **Tech Stack:** mise, jdx/mise-action, GitHub Actions, pnpm, TypeScript ビルド (`tsc`)。
 
@@ -16,22 +16,23 @@
 
 ## File Structure
 
-| ファイル | 操作 | 責務 |
-| --- | --- | --- |
-| `mise.toml` | 新規 | node/pnpm/apm の SSoT |
-| `package.json` | 修正 | `engines` ブロック削除 |
-| `.github/workflows/deploy.yml` | 修正 | `Build` ジョブを mise-action 化 |
-| `.github/workflows/dependency-review.yml` | 修正 | `Build-Check` ジョブを mise-action 化 |
-| `.apm/instructions/setup.instructions.md` | 修正 | ローカル構築手順を mise ベースへ |
-| `.apm/instructions/github-ops.instructions.md` | 修正 | CI が mise-action 経由になった旨 |
-| `.apm/instructions/apm-workflow.instructions.md` | 修正 | apm CLI 本体の版は mise.toml 管理 |
-| `README.md` | 確認のみ | バージョン直書き無しを確認 (変更なし想定) |
+| ファイル                                         | 操作     | 責務                                      |
+| ------------------------------------------------ | -------- | ----------------------------------------- |
+| `mise.toml`                                      | 新規     | node/pnpm/apm の SSoT                     |
+| `package.json`                                   | 修正     | `engines` ブロック削除                    |
+| `.github/workflows/deploy.yml`                   | 修正     | `Build` ジョブを mise-action 化           |
+| `.github/workflows/dependency-review.yml`        | 修正     | `Build-Check` ジョブを mise-action 化     |
+| `.apm/instructions/setup.instructions.md`        | 修正     | ローカル構築手順を mise ベースへ          |
+| `.apm/instructions/github-ops.instructions.md`   | 修正     | CI が mise-action 経由になった旨          |
+| `.apm/instructions/apm-workflow.instructions.md` | 修正     | apm CLI 本体の版は mise.toml 管理         |
+| `README.md`                                      | 確認のみ | バージョン直書き無しを確認 (変更なし想定) |
 
 ---
 
 ## Task 1: `mise.toml` を作成 (SSoT)
 
 **Files:**
+
 - Create: `mise.toml`
 
 - [ ] **Step 1: `mise.toml` を作成**
@@ -51,26 +52,24 @@ pnpm = "11.5.2"
 
 - [ ] **Step 2: 設定を trust**
 
-Run: `mise trust mise.toml`
-Expected: `mise trusted /home/ore/codes/bingo/mise.toml` (またはそれに準ずる trusted メッセージ)
+Run: `mise trust mise.toml` Expected: `mise trusted /home/ore/codes/bingo/mise.toml` (またはそれに準ずる trusted メッセージ)
 
 - [ ] **Step 3: ツールを導入**
 
-Run: `mise install`
-Expected: node 24.16.0 / pnpm 11.5.2 / github:microsoft/apm 0.18.0 がインストールされ、apm は SLSA provenance / artifact attestation 検証を通過して `✓ installed` となる。
+Run: `mise install` Expected: node 24.16.0 / pnpm 11.5.2 / github:microsoft/apm 0.18.0 がインストールされ、apm は SLSA provenance / artifact attestation 検証を通過して `✓ installed` となる。
 
 - [ ] **Step 4: 解決バージョンを検証**
 
-Run: `mise current`
-Expected (順不同):
+Run: `mise current` Expected (順不同):
+
 ```
 node 24.16.0
 pnpm 11.5.2
 github:microsoft/apm 0.18.0
 ```
 
-Run: `mise exec -- node --version && mise exec -- pnpm --version && mise exec -- apm --version`
-Expected:
+Run: `mise exec -- node --version && mise exec -- pnpm --version && mise exec -- apm --version` Expected:
+
 ```
 v24.16.0
 11.5.2
@@ -79,16 +78,13 @@ Agent Package Manager (APM) CLI version 0.18.0 (c393f33)
 
 - [ ] **Step 5: pnpm が mise tool として解決されることを検証**
 
-Run: `mise which pnpm`
-Expected: `/home/ore/.local/share/mise/installs/pnpm/11.5.2/...` 配下のパス (node install ディレクトリ配下ではないこと)
+Run: `mise which pnpm` Expected: `/home/ore/.local/share/mise/installs/pnpm/11.5.2/...` 配下のパス (node install ディレクトリ配下ではないこと)
 
 - [ ] **Step 6: 既存のインストール/ビルドが通ることを検証**
 
-Run: `mise exec -- pnpm i --frozen-lockfile`
-Expected: lockfile 不整合エラーなく完了 (lockfileVersion 9.0 / pnpm 11.x 互換)
+Run: `mise exec -- pnpm i --frozen-lockfile` Expected: lockfile 不整合エラーなく完了 (lockfileVersion 9.0 / pnpm 11.x 互換)
 
-Run: `mise exec -- pnpm run build`
-Expected: `tsc -b` が成功し終了コード 0
+Run: `mise exec -- pnpm run build` Expected: `tsc -b` が成功し終了コード 0
 
 - [ ] **Step 7: コミット**
 
@@ -102,6 +98,7 @@ git commit -m "feat: mise.toml を追加し node/pnpm/apm を SSoT 管理"
 ## Task 2: `package.json` の `engines` を削除
 
 **Files:**
+
 - Modify: `package.json`
 
 - [ ] **Step 1: `engines` ブロックを削除**
@@ -109,6 +106,7 @@ git commit -m "feat: mise.toml を追加し node/pnpm/apm を SSoT 管理"
 `package.json` の以下のブロック (タブインデント) を**丸ごと削除**する。位置は `scripts` ブロック直後・`husky` ブロック直前。
 
 削除対象 (この4行):
+
 ```json
 	"engines": {
 		"node": ">=24.16.0",
@@ -120,16 +118,13 @@ git commit -m "feat: mise.toml を追加し node/pnpm/apm を SSoT 管理"
 
 - [ ] **Step 2: JSON が壊れていないことを検証**
 
-Run: `mise exec -- node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('ok')"`
-Expected: `ok`
+Run: `mise exec -- node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('ok')"` Expected: `ok`
 
-Run: `mise exec -- node -e "const p=require('./package.json'); console.log('engines' in p ? 'STILL PRESENT' : 'removed')"`
-Expected: `removed`
+Run: `mise exec -- node -e "const p=require('./package.json'); console.log('engines' in p ? 'STILL PRESENT' : 'removed')"` Expected: `removed`
 
 - [ ] **Step 3: engines 撤去後もインストールが通ることを検証**
 
-Run: `mise exec -- pnpm i --frozen-lockfile`
-Expected: engine 関連の警告/エラーなく完了 (`.npmrc` に engine-strict 無し)
+Run: `mise exec -- pnpm i --frozen-lockfile` Expected: engine 関連の警告/エラーなく完了 (`.npmrc` に engine-strict 無し)
 
 - [ ] **Step 4: コミット**
 
@@ -145,6 +140,7 @@ git commit -m "chore: package.json の engines を削除 (mise.toml に一本化
 ## Task 3: `deploy.yml` の `Build` ジョブを mise-action 化
 
 **Files:**
+
 - Modify: `.github/workflows/deploy.yml`
 
 - [ ] **Step 1: `Build` ジョブを書き換え**
@@ -152,57 +148,67 @@ git commit -m "chore: package.json の engines を削除 (mise.toml に一本化
 `jobs.Build` の (a) `strategy.matrix` ブロックを削除し、(b) `actions/setup-node` と `pnpm/action-setup` の2ステップを `jdx/mise-action` の1ステップに置換する。他ステップ (permissions monitor / Confirm Check / checkout / actionlint / Install / Build / Clean Up / Upload) は維持する。
 
 置換前 (該当部分):
+
 ```yaml
-  Build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [24.16.0]
-    timeout-minutes: 5
-    permissions: {}
-    steps:
+Build:
+  runs-on: ubuntu-latest
+  strategy:
+    matrix:
+      node-version: [24.16.0]
+  timeout-minutes: 5
+  permissions: {}
+  steps:
 ```
+
 置換後:
+
 ```yaml
-  Build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions: {}
-    steps:
+Build:
+  runs-on: ubuntu-latest
+  timeout-minutes: 5
+  permissions: {}
+  steps:
 ```
 
 置換前 (該当部分):
+
 ```yaml
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: ${{ matrix.node-version }}
-          check-latest: true
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: 11.1.2
+- uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+  with:
+    node-version: ${{ matrix.node-version }}
+    check-latest: true
+- uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+  with:
+    version: 11.1.2
 ```
+
 置換後:
+
 ```yaml
-      # node / pnpm のバージョンは mise.toml を SSoT とする。apm は CI で不要なので install 対象外。
-      # mise 本体の版は pnpm の aqua アセット解決に影響する実績があるため version をピンする。
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          version: 2026.6.1
-          install_args: "node pnpm"
+# node / pnpm のバージョンは mise.toml を SSoT とする。apm は CI で不要なので install 対象外。
+# mise 本体の版は pnpm の aqua アセット解決に影響する実績があるため version をピンする。
+- uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+  with:
+    version: 2026.6.1
+    install_args: "node pnpm"
 ```
 
 - [ ] **Step 2: actionlint で検証**
 
 Run:
+
 ```bash
 docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint:1.7.4
 ```
+
 Expected: 終了コード 0、エラー出力なし。
 
 > **docker が使えない場合の代替 (スキップ不可)**: `deploy.yml` の actionlint ステップは `deploy.yml` 自身の中にあり、`deploy.yml` は PR では実行されない (Task 6 Step 3 参照)。つまりこのワークフロー編集に対する**マージ前の YAML 検証はローカル actionlint が唯一**であり、CI 委譲はできない。docker が無い場合は mise 経由で actionlint を実行すること:
+>
 > ```bash
 > mise x actionlint@1.7.4 -- actionlint
 > ```
+>
 > Expected: 終了コード 0、エラー出力なし。(actionlint は mise registry に存在: `aqua:rhysd/actionlint`)
 
 - [ ] **Step 3: コミット**
@@ -217,6 +223,7 @@ git commit -m "ci: deploy.yml の node/pnpm 導入を mise-action に置換"
 ## Task 4: `dependency-review.yml` の `Build-Check` ジョブを mise-action 化
 
 **Files:**
+
 - Modify: `.github/workflows/dependency-review.yml`
 
 - [ ] **Step 1: `Build-Check` ジョブを書き換え**
@@ -224,51 +231,59 @@ git commit -m "ci: deploy.yml の node/pnpm 導入を mise-action に置換"
 `jobs.Build-Check` のみ変更する (`jobs.Dependency-Review` は node 不使用のため変更しない)。
 
 置換前:
+
 ```yaml
-  Build-Check:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [24.16.0]
-    timeout-minutes: 3
-    permissions: {}
-    steps:
+Build-Check:
+  runs-on: ubuntu-latest
+  strategy:
+    matrix:
+      node-version: [24.16.0]
+  timeout-minutes: 3
+  permissions: {}
+  steps:
 ```
+
 置換後:
+
 ```yaml
-  Build-Check:
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    permissions: {}
-    steps:
+Build-Check:
+  runs-on: ubuntu-latest
+  timeout-minutes: 3
+  permissions: {}
+  steps:
 ```
 
 置換前:
+
 ```yaml
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: ${{ matrix.node-version }}
-          check-latest: true
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: 11.1.2
+- uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+  with:
+    node-version: ${{ matrix.node-version }}
+    check-latest: true
+- uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+  with:
+    version: 11.1.2
 ```
+
 置換後:
+
 ```yaml
-      # node / pnpm のバージョンは mise.toml を SSoT とする。apm は CI で不要なので install 対象外。
-      # mise 本体の版は pnpm の aqua アセット解決に影響する実績があるため version をピンする。
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          version: 2026.6.1
-          install_args: "node pnpm"
+# node / pnpm のバージョンは mise.toml を SSoT とする。apm は CI で不要なので install 対象外。
+# mise 本体の版は pnpm の aqua アセット解決に影響する実績があるため version をピンする。
+- uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+  with:
+    version: 2026.6.1
+    install_args: "node pnpm"
 ```
 
 - [ ] **Step 2: actionlint で検証**
 
 Run:
+
 ```bash
 docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint:1.7.4
 ```
+
 Expected: 終了コード 0、エラー出力なし。(docker 不可なら Task 3 Step 2 と同じく `mise x actionlint@1.7.4 -- actionlint` を使う。`dependency-review.yml` も含め全ワークフローが lint される)
 
 - [ ] **Step 3: コミット**
@@ -283,6 +298,7 @@ git commit -m "ci: dependency-review.yml の node/pnpm 導入を mise-action に
 ## Task 5: ドキュメントを mise ベースへ更新
 
 **Files:**
+
 - Modify: `.apm/instructions/setup.instructions.md`
 - Modify: `.apm/instructions/github-ops.instructions.md`
 - Modify: `.apm/instructions/apm-workflow.instructions.md`
@@ -290,6 +306,7 @@ git commit -m "ci: dependency-review.yml の node/pnpm 導入を mise-action に
 - [ ] **Step 1: `setup.instructions.md` のローカル構築手順を更新**
 
 置換前:
+
 ```markdown
 ## ローカル環境構築
 
@@ -298,14 +315,14 @@ git commit -m "ci: dependency-review.yml の node/pnpm 導入を mise-action に
 - `pnpm i --frozen-lockfile`
 - `pnpm run dev`
 ```
+
 置換後:
+
 ```markdown
 ## ローカル環境構築
 
 - [mise](https://mise.jdx.dev/) (>= 2026.6.1) を導入する (node / pnpm / apm のバージョン管理に使用)
-  - Linux ホストでは、pnpm (Node SEA バイナリ) が `libatomic.so.1` を要求するため
-    `libatomic1` を導入しておく (例: `sudo apt-get install -y libatomic1`)。
-    GitHub Actions の `ubuntu-latest` 等には標準装備のため CI では不要。
+  - Linux ホストでは、pnpm (Node SEA バイナリ) が `libatomic.so.1` を要求するため `libatomic1` を導入しておく (例: `sudo apt-get install -y libatomic1`)。GitHub Actions の `ubuntu-latest` 等には標準装備のため CI では不要。
 - `git clone`
 - `mise trust && mise install` で `mise.toml` に固定された node / pnpm / apm を導入する
 - `pnpm i --frozen-lockfile`
@@ -313,16 +330,13 @@ git commit -m "ci: dependency-review.yml の node/pnpm 導入を mise-action に
 
 ## バージョン管理 (mise)
 
-node / pnpm / apm CLI 本体のバージョンは `mise.toml` を唯一の真実源 (SSoT) とする。
-バージョンを上げる際は `mise.toml` を編集して `mise install` する (apm の `apm self-update` や
-`apm doctor` の更新催促には従わない)。CI も `jdx/mise-action` (mise 本体は `version: 2026.6.1`
-にピン) 経由で同じ `mise.toml` を消費する。mise 本体は最低 2026.6.1 を要する
-(これ未満では pnpm 11.5.2 の aqua アセット解決に失敗する)。
+node / pnpm / apm CLI 本体のバージョンは `mise.toml` を唯一の真実源 (SSoT) とする。バージョンを上げる際は `mise.toml` を編集して `mise install` する (apm の `apm self-update` や `apm doctor` の更新催促には従わない)。CI も `jdx/mise-action` (mise 本体は `version: 2026.6.1` にピン) 経由で同じ `mise.toml` を消費する。mise 本体は最低 2026.6.1 を要する (これ未満では pnpm 11.5.2 の aqua アセット解決に失敗する)。
 ```
 
 - [ ] **Step 2: `github-ops.instructions.md` の GitHub Actions 節を更新**
 
 置換前:
+
 ```markdown
 ## GitHub Actions
 
@@ -332,7 +346,9 @@ node / pnpm / apm CLI 本体のバージョンは `mise.toml` を唯一の真実
 - 放置 Issue/PR の自動削除
 - CodeQL で脆弱性を含むコードの検出 (TypeScript のみ)
 ```
+
 置換後:
+
 ```markdown
 ## GitHub Actions
 
@@ -344,33 +360,28 @@ node / pnpm / apm CLI 本体のバージョンは `mise.toml` を唯一の真実
 
 ### ツールチェーン (node / pnpm)
 
-CI の node / pnpm は `mise.toml` を SSoT とし、`jdx/mise-action` (コミット SHA ピン) で導入する
-(`install_args: "node pnpm"` で対象を限定)。apm は CI では使用しないため導入しない。
+CI の node / pnpm は `mise.toml` を SSoT とし、`jdx/mise-action` (コミット SHA ピン) で導入する (`install_args: "node pnpm"` で対象を限定)。apm は CI では使用しないため導入しない。
 ```
 
 - [ ] **Step 3: `apm-workflow.instructions.md` に apm CLI バージョン管理の節を追記**
 
 `## Source of Truth` 節の直後に以下の節を挿入する:
+
 ```markdown
 ## APM CLI 本体のバージョン
 
-APM CLI 本体 (`apm` バイナリ) のバージョンは `mise.toml` (`github:microsoft/apm`) を SSoT として
-管理する。更新は `mise.toml` の version を上げて `mise install` する。`apm self-update` や
-`apm doctor` の更新催促には従わない (mise 管理外のグローバルインストールを増やさないため)。
+APM CLI 本体 (`apm` バイナリ) のバージョンは `mise.toml` (`github:microsoft/apm`) を SSoT として管理する。更新は `mise.toml` の version を上げて `mise install` する。`apm self-update` や `apm doctor` の更新催促には従わない (mise 管理外のグローバルインストールを増やさないため)。
 ```
 
 - [ ] **Step 4: ドキュメント整合性を検証**
 
-Run: `mise exec -- pnpm exec prettier --check ".apm/instructions/*.md"`
-Expected: 対象ファイルが `prettier` 整形済み (差分なし)。差分があれば次の Run で整形する。
+Run: `mise exec -- pnpm exec prettier --check ".apm/instructions/*.md"` Expected: 対象ファイルが `prettier` 整形済み (差分なし)。差分があれば次の Run で整形する。
 
-Run (必要時): `mise exec -- pnpm exec prettier --write ".apm/instructions/*.md"`
-Expected: 整形完了。
+Run (必要時): `mise exec -- pnpm exec prettier --write ".apm/instructions/*.md"` Expected: 整形完了。
 
 - [ ] **Step 5: README にバージョン直書きが無いことを確認 (変更なし想定)**
 
-Run: `git grep -nE "24\.1[0-9]\.[0-9]|11\.[0-9]+\.[0-9]+|engines" -- README.md`
-Expected: ヒットなし (出力空)。ヒットした場合のみ該当箇所を mise ベースの表現に修正する。
+Run: `git grep -nE "24\.1[0-9]\.[0-9]|11\.[0-9]+\.[0-9]+|engines" -- README.md` Expected: ヒットなし (出力空)。ヒットした場合のみ該当箇所を mise ベースの表現に修正する。
 
 - [ ] **Step 6: コミット**
 
@@ -390,25 +401,26 @@ git commit -m "docs: 環境構築/CI/APM 運用の記述を mise ベースに更
 - [ ] **Step 1: ローカル一括検証 (verification-before-completion 相当)**
 
 Run:
+
 ```bash
 mise exec -- pnpm i --frozen-lockfile && mise exec -- pnpm run build
 ```
+
 Expected: 双方成功 (終了コード 0)。`pnpm run build` 後に生成された `src/ts/*.js` 等のビルド成果物は commit しない (元から git 管理外/clean であること)。
 
-Run: `git status --porcelain`
-Expected: 追跡対象の未コミット変更が無いこと (ビルド生成物のみが出る場合は無視 or 既存 .gitignore 範囲内であること)。
+Run: `git status --porcelain` Expected: 追跡対象の未コミット変更が無いこと (ビルド生成物のみが出る場合は無視 or 既存 .gitignore 範囲内であること)。
 
 - [ ] **Step 2: push**
 
 ```bash
 git push
 ```
+
 Expected: `chore/mise-version-management` に反映され、PR #383 が更新される。
 
 - [ ] **Step 3: CI の green を確認**
 
-Run: `gh pr checks 383 --watch`
-Expected: `Dependency Check / Build-Check` (mise-action 化を検証)、`Dependency Check / Dependency-Review`、および CodeQL (GitHub 既定設定) がすべて pass。
+Run: `gh pr checks 383 --watch` Expected: `Dependency Check / Build-Check` (mise-action 化を検証)、`Dependency Check / Dependency-Review`、および CodeQL (GitHub 既定設定) がすべて pass。
 
 > **重要 (CI トリガの差異)**: `deploy.yml` は `on: push (branches: main)` / `workflow_dispatch` のみで、**PR では実行されない**。よって `deploy.yml` の `Build` ジョブ (mise-action 化) は PR の CI では検証されず、**main へマージ後の deploy 実行が初回**となる。PR 段階での `deploy.yml` の担保は (a) ローカル actionlint (Task 3 Step 2)、(b) PR で実際に走る `dependency-review.yml` の `Build-Check` と同一パターンであること、の2点。マージ後は次の Step で deploy を必ず確認する。
 
@@ -416,9 +428,7 @@ Expected: `Dependency Check / Build-Check` (mise-action 化を検証)、`Depende
 
 main へマージ後、`deploy.yml` が走るので mise-action 経由の `Build` ジョブ初回実行を確認する。
 
-Run: `gh run list --workflow deploy.yml --branch main --limit 1`
-その実行 ID に対し `gh run watch <run-id>`
-Expected: `Build` (mise で node/pnpm 導入 → `pnpm run build`) と `Deploy` が成功し、GitHub Pages へ反映される。失敗時は mise-action の挙動 (特に `permissions: {}` 下での GitHub からの pnpm 取得レート制限) を確認し、必要なら `Build` ジョブに `permissions: { contents: read }` を付与する。
+Run: `gh run list --workflow deploy.yml --branch main --limit 1` その実行 ID に対し `gh run watch <run-id>` Expected: `Build` (mise で node/pnpm 導入 → `pnpm run build`) と `Deploy` が成功し、GitHub Pages へ反映される。失敗時は mise-action の挙動 (特に `permissions: {}` 下での GitHub からの pnpm 取得レート制限) を確認し、必要なら `Build` ジョブに `permissions: { contents: read }` を付与する。
 
 - [ ] **Step 4: Copilot レビュー応答ループ**
 

--- a/docs/superpowers/plans/2026-06-09-mise-version-management.md
+++ b/docs/superpowers/plans/2026-06-09-mise-version-management.md
@@ -1,0 +1,422 @@
+# mise によるバージョン管理 (node / pnpm / apm) 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `mise.toml` を node / pnpm / apm のバージョン情報の唯一の真実源 (SSoT) とし、`package.json` の `engines` を撤去、ローカルと CI を mise ベースに統一する。
+
+**Architecture:** リポジトリ直下の `mise.toml` に node/pnpm/apm を exact ピン。ローカルは `mise install`、CI は `jdx/mise-action` (SHA ピン) で同じ `mise.toml` を消費する。apm は mise の `github` バックエンドで microsoft/apm の Release を取得 (PyInstaller onedir を `extract_all` で展開、`exe` で起動エントリ指定)。
+
+**Tech Stack:** mise, jdx/mise-action, GitHub Actions, pnpm, TypeScript ビルド (`tsc`)。
+
+**前提:** これはインフラ/設定の変更であり、ユニットテスト対象コードは無い。各タスクの「テスト」は**検証コマンド + 期待出力**で表現する。作業は既存ブランチ `chore/mise-version-management` (PR #383) 上で行い、各タスクごとにコミットする。`Co-Authored-By` トレーラは付与しない。
+
+**確定バージョン:** node `24.16.0` / pnpm `11.5.2` / apm `0.18.0`
+
+---
+
+## File Structure
+
+| ファイル | 操作 | 責務 |
+| --- | --- | --- |
+| `mise.toml` | 新規 | node/pnpm/apm の SSoT |
+| `package.json` | 修正 | `engines` ブロック削除 |
+| `.github/workflows/deploy.yml` | 修正 | `Build` ジョブを mise-action 化 |
+| `.github/workflows/dependency-review.yml` | 修正 | `Build-Check` ジョブを mise-action 化 |
+| `.apm/instructions/setup.instructions.md` | 修正 | ローカル構築手順を mise ベースへ |
+| `.apm/instructions/github-ops.instructions.md` | 修正 | CI が mise-action 経由になった旨 |
+| `.apm/instructions/apm-workflow.instructions.md` | 修正 | apm CLI 本体の版は mise.toml 管理 |
+| `README.md` | 確認のみ | バージョン直書き無しを確認 (変更なし想定) |
+
+---
+
+## Task 1: `mise.toml` を作成 (SSoT)
+
+**Files:**
+- Create: `mise.toml`
+
+- [ ] **Step 1: `mise.toml` を作成**
+
+ファイル全文 (リポジトリ直下):
+
+```toml
+[tools]
+node = "24.16.0"
+pnpm = "11.5.2"
+"github:microsoft/apm" = { version = "0.18.0", exe = "apm", extract_all = "true" }
+```
+
+> 補足: `extract_all = "true"` は mise 公式ドキュメント (ubi/github backend) の正準表記であり、クォート付き文字列が正しい (PR #383 で検証・確定済み)。`true` に変更しないこと。
+
+- [ ] **Step 2: 設定を trust**
+
+Run: `mise trust mise.toml`
+Expected: `mise trusted /home/ore/codes/bingo/mise.toml` (またはそれに準ずる trusted メッセージ)
+
+- [ ] **Step 3: ツールを導入**
+
+Run: `mise install`
+Expected: node 24.16.0 / pnpm 11.5.2 / github:microsoft/apm 0.18.0 がインストールされ、apm は SLSA provenance / artifact attestation 検証を通過して `✓ installed` となる。
+
+- [ ] **Step 4: 解決バージョンを検証**
+
+Run: `mise current`
+Expected (順不同):
+```
+node 24.16.0
+pnpm 11.5.2
+github:microsoft/apm 0.18.0
+```
+
+Run: `mise exec -- node --version && mise exec -- pnpm --version && mise exec -- apm --version`
+Expected:
+```
+v24.16.0
+11.5.2
+Agent Package Manager (APM) CLI version 0.18.0 (c393f33)
+```
+
+- [ ] **Step 5: pnpm が mise tool として解決されることを検証**
+
+Run: `mise which pnpm`
+Expected: `/home/ore/.local/share/mise/installs/pnpm/11.5.2/...` 配下のパス (node install ディレクトリ配下ではないこと)
+
+- [ ] **Step 6: 既存のインストール/ビルドが通ることを検証**
+
+Run: `mise exec -- pnpm i --frozen-lockfile`
+Expected: lockfile 不整合エラーなく完了 (lockfileVersion 9.0 / pnpm 11.x 互換)
+
+Run: `mise exec -- pnpm run build`
+Expected: `tsc -b` が成功し終了コード 0
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add mise.toml
+git commit -m "feat: mise.toml を追加し node/pnpm/apm を SSoT 管理"
+```
+
+---
+
+## Task 2: `package.json` の `engines` を削除
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: `engines` ブロックを削除**
+
+`package.json` の以下のブロック (タブインデント) を**丸ごと削除**する。位置は `scripts` ブロック直後・`husky` ブロック直前。
+
+削除対象 (この4行):
+```json
+	"engines": {
+		"node": ">=24.16.0",
+		"pnpm": ">=11.1.2"
+	},
+```
+
+削除後、`scripts` の閉じ `},` の直後に `"husky": {` が続く形になること。
+
+- [ ] **Step 2: JSON が壊れていないことを検証**
+
+Run: `mise exec -- node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('ok')"`
+Expected: `ok`
+
+Run: `mise exec -- node -e "const p=require('./package.json'); console.log('engines' in p ? 'STILL PRESENT' : 'removed')"`
+Expected: `removed`
+
+- [ ] **Step 3: engines 撤去後もインストールが通ることを検証**
+
+Run: `mise exec -- pnpm i --frozen-lockfile`
+Expected: engine 関連の警告/エラーなく完了 (`.npmrc` に engine-strict 無し)
+
+- [ ] **Step 4: コミット**
+
+`prepare`/husky の pre-commit (lint-staged → prettier) が `package.json` を整形する場合があるため、整形結果ごとコミットする。
+
+```bash
+git add package.json
+git commit -m "chore: package.json の engines を削除 (mise.toml に一本化)"
+```
+
+---
+
+## Task 3: `deploy.yml` の `Build` ジョブを mise-action 化
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml`
+
+- [ ] **Step 1: `Build` ジョブを書き換え**
+
+`jobs.Build` の (a) `strategy.matrix` ブロックを削除し、(b) `actions/setup-node` と `pnpm/action-setup` の2ステップを `jdx/mise-action` の1ステップに置換する。他ステップ (permissions monitor / Confirm Check / checkout / actionlint / Install / Build / Clean Up / Upload) は維持する。
+
+置換前 (該当部分):
+```yaml
+  Build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [24.16.0]
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+```
+置換後:
+```yaml
+  Build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+```
+
+置換前 (該当部分):
+```yaml
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          check-latest: true
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.1.2
+```
+置換後:
+```yaml
+      # node / pnpm のバージョンは mise.toml を SSoT とする。mise 本体は最新を使用 (各ツールは exact ピンのため解決結果は不変)。apm は CI で不要なので install 対象外。
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install_args: "node pnpm"
+```
+
+- [ ] **Step 2: actionlint で検証**
+
+Run:
+```bash
+docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint:1.7.4
+```
+Expected: 終了コード 0、エラー出力なし。
+
+> docker が使えない環境の場合はこのローカル検証をスキップし、CI の "Run actionlint in workflow Directory" ステップ (deploy.yml 内) と push 後の Actions 実行に委ねる旨をコミットメッセージ/PR に明記すること。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "ci: deploy.yml の node/pnpm 導入を mise-action に置換"
+```
+
+---
+
+## Task 4: `dependency-review.yml` の `Build-Check` ジョブを mise-action 化
+
+**Files:**
+- Modify: `.github/workflows/dependency-review.yml`
+
+- [ ] **Step 1: `Build-Check` ジョブを書き換え**
+
+`jobs.Build-Check` のみ変更する (`jobs.Dependency-Review` は node 不使用のため変更しない)。
+
+置換前:
+```yaml
+  Build-Check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [24.16.0]
+    timeout-minutes: 3
+    permissions: {}
+    steps:
+```
+置換後:
+```yaml
+  Build-Check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions: {}
+    steps:
+```
+
+置換前:
+```yaml
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          check-latest: true
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.1.2
+```
+置換後:
+```yaml
+      # node / pnpm のバージョンは mise.toml を SSoT とする。apm は CI で不要なので install 対象外。
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install_args: "node pnpm"
+```
+
+- [ ] **Step 2: actionlint で検証**
+
+Run:
+```bash
+docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint:1.7.4
+```
+Expected: 終了コード 0、エラー出力なし。(docker 不可なら Task 3 Step 2 と同様に CI 委譲)
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add .github/workflows/dependency-review.yml
+git commit -m "ci: dependency-review.yml の node/pnpm 導入を mise-action に置換"
+```
+
+---
+
+## Task 5: ドキュメントを mise ベースへ更新
+
+**Files:**
+- Modify: `.apm/instructions/setup.instructions.md`
+- Modify: `.apm/instructions/github-ops.instructions.md`
+- Modify: `.apm/instructions/apm-workflow.instructions.md`
+
+- [ ] **Step 1: `setup.instructions.md` のローカル構築手順を更新**
+
+置換前:
+```markdown
+## ローカル環境構築
+
+- `git clone`
+- node と pnpm を `package.json` で指定されたバージョンに設定
+- `pnpm i --frozen-lockfile`
+- `pnpm run dev`
+```
+置換後:
+```markdown
+## ローカル環境構築
+
+- [mise](https://mise.jdx.dev/) を導入する (node / pnpm / apm のバージョン管理に使用)
+- `git clone`
+- `mise trust && mise install` で `mise.toml` に固定された node / pnpm / apm を導入する
+- `pnpm i --frozen-lockfile`
+- `pnpm run dev`
+
+## バージョン管理 (mise)
+
+node / pnpm / apm CLI 本体のバージョンは `mise.toml` を唯一の真実源 (SSoT) とする。
+バージョンを上げる際は `mise.toml` を編集して `mise install` する (apm の `apm self-update` や
+`apm doctor` の更新催促には従わない)。CI も `jdx/mise-action` 経由で同じ `mise.toml` を消費する。
+```
+
+- [ ] **Step 2: `github-ops.instructions.md` の GitHub Actions 節を更新**
+
+置換前:
+```markdown
+## GitHub Actions
+
+- GitHub Pages への deploy
+- 外形監視
+- 依存モジュールの脆弱性検査
+- 放置 Issue/PR の自動削除
+- CodeQL で脆弱性を含むコードの検出 (TypeScript のみ)
+```
+置換後:
+```markdown
+## GitHub Actions
+
+- GitHub Pages への deploy
+- 外形監視
+- 依存モジュールの脆弱性検査
+- 放置 Issue/PR の自動削除
+- CodeQL で脆弱性を含むコードの検出 (TypeScript のみ)
+
+### ツールチェーン (node / pnpm)
+
+CI の node / pnpm は `mise.toml` を SSoT とし、`jdx/mise-action` (コミット SHA ピン) で導入する
+(`install_args: "node pnpm"` で対象を限定)。apm は CI では使用しないため導入しない。
+```
+
+- [ ] **Step 3: `apm-workflow.instructions.md` に apm CLI バージョン管理の節を追記**
+
+`## Source of Truth` 節の直後に以下の節を挿入する:
+```markdown
+## APM CLI 本体のバージョン
+
+APM CLI 本体 (`apm` バイナリ) のバージョンは `mise.toml` (`github:microsoft/apm`) を SSoT として
+管理する。更新は `mise.toml` の version を上げて `mise install` する。`apm self-update` や
+`apm doctor` の更新催促には従わない (mise 管理外のグローバルインストールを増やさないため)。
+```
+
+- [ ] **Step 4: ドキュメント整合性を検証**
+
+Run: `mise exec -- pnpm exec prettier --check ".apm/instructions/*.md"`
+Expected: 対象ファイルが `prettier` 整形済み (差分なし)。差分があれば次の Run で整形する。
+
+Run (必要時): `mise exec -- pnpm exec prettier --write ".apm/instructions/*.md"`
+Expected: 整形完了。
+
+- [ ] **Step 5: README にバージョン直書きが無いことを確認 (変更なし想定)**
+
+Run: `git grep -nE "24\.1[0-9]\.[0-9]|11\.[0-9]+\.[0-9]+|engines" -- README.md`
+Expected: ヒットなし (出力空)。ヒットした場合のみ該当箇所を mise ベースの表現に修正する。
+
+- [ ] **Step 6: コミット**
+
+husky pre-commit (lint-staged → prettier) が md を整形するためそれごとコミットする。
+
+```bash
+git add .apm/instructions/setup.instructions.md .apm/instructions/github-ops.instructions.md .apm/instructions/apm-workflow.instructions.md
+git commit -m "docs: 環境構築/CI/APM 運用の記述を mise ベースに更新"
+```
+
+---
+
+## Task 6: 最終検証・push・CI 確認
+
+**Files:** なし (検証と push のみ)
+
+- [ ] **Step 1: ローカル一括検証 (verification-before-completion 相当)**
+
+Run:
+```bash
+mise exec -- pnpm i --frozen-lockfile && mise exec -- pnpm run build
+```
+Expected: 双方成功 (終了コード 0)。`pnpm run build` 後に生成された `src/ts/*.js` 等のビルド成果物は commit しない (元から git 管理外/clean であること)。
+
+Run: `git status --porcelain`
+Expected: 追跡対象の未コミット変更が無いこと (ビルド生成物のみが出る場合は無視 or 既存 .gitignore 範囲内であること)。
+
+- [ ] **Step 2: push**
+
+```bash
+git push
+```
+Expected: `chore/mise-version-management` に反映され、PR #383 が更新される。
+
+- [ ] **Step 3: CI の green を確認**
+
+Run: `gh pr checks 383 --watch`
+Expected: `Dependency Check / Build-Check` (mise-action 化を検証)、`Dependency Check / Dependency-Review`、および CodeQL (GitHub 既定設定) がすべて pass。
+
+> **重要 (CI トリガの差異)**: `deploy.yml` は `on: push (branches: main)` / `workflow_dispatch` のみで、**PR では実行されない**。よって `deploy.yml` の `Build` ジョブ (mise-action 化) は PR の CI では検証されず、**main へマージ後の deploy 実行が初回**となる。PR 段階での `deploy.yml` の担保は (a) ローカル actionlint (Task 3 Step 2)、(b) PR で実際に走る `dependency-review.yml` の `Build-Check` と同一パターンであること、の2点。マージ後は次の Step で deploy を必ず確認する。
+
+- [ ] **Step 3b: マージ後の deploy を確認 (マージ実施時)**
+
+main へマージ後、`deploy.yml` が走るので mise-action 経由の `Build` ジョブ初回実行を確認する。
+
+Run: `gh run list --workflow deploy.yml --branch main --limit 1`
+その実行 ID に対し `gh run watch <run-id>`
+Expected: `Build` (mise で node/pnpm 導入 → `pnpm run build`) と `Deploy` が成功し、GitHub Pages へ反映される。失敗時は mise-action の挙動 (特に `permissions: {}` 下での GitHub からの pnpm 取得レート制限) を確認し、必要なら `Build` ジョブに `permissions: { contents: read }` を付与する。
+
+- [ ] **Step 4: Copilot レビュー応答ループ**
+
+push により Copilot レビューが付いた場合は、`.apm/instructions/local-dev-workflow.instructions.md` の「PR レビュー応答ループ」(検知 → 妥当性判断 → 対応 → resolve) を全スレッド resolve まで実施する。
+
+- [ ] **Step 5: PR ラベルの最終確認**
+
+実装が乗ったことで PR は「ツール/バージョン管理 + ドキュメント」の変更となる。`.github/release.yml` の category 対応ラベル (`dependencies` 等) が適切か確認する (現状 `dependencies` 付与済み)。
+
+---
+
+## Self-Review メモ (この計画自体の確認結果)
+
+- **Spec coverage**: spec の各項目に対応タスクあり — mise.toml(Task1) / engines 削除(Task2) / CI mise-action(Task3,4) / docs(Task5) / 検証(各タスク + Task6)。スコープ外 (dedupe-apm-lock、apm.yml 依存ピン) には意図的にタスクを設けていない。
+- **Placeholder scan**: TBD/TODO 無し。すべての編集は old→new の具体ブロックとコマンド+期待出力で記述。
+- **Type/値の一貫性**: バージョン (node 24.16.0 / pnpm 11.5.2 / apm 0.18.0)、mise-action SHA (`dba19683ed58901619b14f395a24841710cb4925` # v4.1.0)、`install_args: "node pnpm"`、`extract_all = "true"` が全タスクで一致。

--- a/docs/superpowers/plans/2026-06-09-mise-version-management.md
+++ b/docs/superpowers/plans/2026-06-09-mise-version-management.md
@@ -183,9 +183,11 @@ git commit -m "chore: package.json の engines を削除 (mise.toml に一本化
 ```
 置換後:
 ```yaml
-      # node / pnpm のバージョンは mise.toml を SSoT とする。mise 本体は最新を使用 (各ツールは exact ピンのため解決結果は不変)。apm は CI で不要なので install 対象外。
+      # node / pnpm のバージョンは mise.toml を SSoT とする。apm は CI で不要なので install 対象外。
+      # mise 本体の版は pnpm の aqua アセット解決に影響する実績があるため version をピンする。
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
+          version: 2026.6.1
           install_args: "node pnpm"
 ```
 
@@ -254,8 +256,10 @@ git commit -m "ci: deploy.yml の node/pnpm 導入を mise-action に置換"
 置換後:
 ```yaml
       # node / pnpm のバージョンは mise.toml を SSoT とする。apm は CI で不要なので install 対象外。
+      # mise 本体の版は pnpm の aqua アセット解決に影響する実績があるため version をピンする。
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
+          version: 2026.6.1
           install_args: "node pnpm"
 ```
 
@@ -298,7 +302,10 @@ git commit -m "ci: dependency-review.yml の node/pnpm 導入を mise-action に
 ```markdown
 ## ローカル環境構築
 
-- [mise](https://mise.jdx.dev/) を導入する (node / pnpm / apm のバージョン管理に使用)
+- [mise](https://mise.jdx.dev/) (>= 2026.6.1) を導入する (node / pnpm / apm のバージョン管理に使用)
+  - Linux ホストでは、pnpm (Node SEA バイナリ) が `libatomic.so.1` を要求するため
+    `libatomic1` を導入しておく (例: `sudo apt-get install -y libatomic1`)。
+    GitHub Actions の `ubuntu-latest` 等には標準装備のため CI では不要。
 - `git clone`
 - `mise trust && mise install` で `mise.toml` に固定された node / pnpm / apm を導入する
 - `pnpm i --frozen-lockfile`
@@ -308,7 +315,9 @@ git commit -m "ci: dependency-review.yml の node/pnpm 導入を mise-action に
 
 node / pnpm / apm CLI 本体のバージョンは `mise.toml` を唯一の真実源 (SSoT) とする。
 バージョンを上げる際は `mise.toml` を編集して `mise install` する (apm の `apm self-update` や
-`apm doctor` の更新催促には従わない)。CI も `jdx/mise-action` 経由で同じ `mise.toml` を消費する。
+`apm doctor` の更新催促には従わない)。CI も `jdx/mise-action` (mise 本体は `version: 2026.6.1`
+にピン) 経由で同じ `mise.toml` を消費する。mise 本体は最低 2026.6.1 を要する
+(これ未満では pnpm 11.5.2 の aqua アセット解決に失敗する)。
 ```
 
 - [ ] **Step 2: `github-ops.instructions.md` の GitHub Actions 節を更新**

--- a/docs/superpowers/plans/2026-06-09-mise-version-management.md
+++ b/docs/superpowers/plans/2026-06-09-mise-version-management.md
@@ -42,10 +42,12 @@
 [tools]
 node = "24.16.0"
 pnpm = "11.5.2"
-"github:microsoft/apm" = { version = "0.18.0", exe = "apm", extract_all = "true" }
+"github:microsoft/apm" = { version = "0.18.0", extract_all = "true" }
 ```
 
-> 補足: `extract_all = "true"` は mise 公式ドキュメント (ubi/github backend) の正準表記であり、クォート付き文字列が正しい (PR #383 で検証・確定済み)。`true` に変更しないこと。
+> 補足1: `extract_all = "true"` は mise 公式ドキュメント (ubi/github backend) の正準表記であり、クォート付き文字列が正しい (PR #383 で検証・確定済み)。`true` に変更しないこと。
+>
+> 補足2: `exe` は**指定しない**。公式ドキュメント上 `extract_all` は `exe` / `rename_exe` と非対応であり、`extract_all` 時は install root から bin が解決される。実機検証 (隔離 `MISE_DATA_DIR` での新規インストール) で、`exe` 無し設定でも `mise which apm` が install root の `apm` を解決し `apm --version` → 0.18.0 が動作することを確認済み。`exe` を足さないこと。
 
 - [ ] **Step 2: 設定を trust**
 
@@ -195,7 +197,11 @@ docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint:1.7.4
 ```
 Expected: 終了コード 0、エラー出力なし。
 
-> docker が使えない環境の場合はこのローカル検証をスキップし、CI の "Run actionlint in workflow Directory" ステップ (deploy.yml 内) と push 後の Actions 実行に委ねる旨をコミットメッセージ/PR に明記すること。
+> **docker が使えない場合の代替 (スキップ不可)**: `deploy.yml` の actionlint ステップは `deploy.yml` 自身の中にあり、`deploy.yml` は PR では実行されない (Task 6 Step 3 参照)。つまりこのワークフロー編集に対する**マージ前の YAML 検証はローカル actionlint が唯一**であり、CI 委譲はできない。docker が無い場合は mise 経由で actionlint を実行すること:
+> ```bash
+> mise x actionlint@1.7.4 -- actionlint
+> ```
+> Expected: 終了コード 0、エラー出力なし。(actionlint は mise registry に存在: `aqua:rhysd/actionlint`)
 
 - [ ] **Step 3: コミット**
 
@@ -259,7 +265,7 @@ Run:
 ```bash
 docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint:1.7.4
 ```
-Expected: 終了コード 0、エラー出力なし。(docker 不可なら Task 3 Step 2 と同様に CI 委譲)
+Expected: 終了コード 0、エラー出力なし。(docker 不可なら Task 3 Step 2 と同じく `mise x actionlint@1.7.4 -- actionlint` を使う。`dependency-review.yml` も含め全ワークフローが lint される)
 
 - [ ] **Step 3: コミット**
 

--- a/docs/superpowers/specs/2026-06-09-mise-version-management-design.md
+++ b/docs/superpowers/specs/2026-06-09-mise-version-management-design.md
@@ -5,39 +5,34 @@
 
 ## 背景 / 動機
 
-- 現状 node/pnpm は mise のグローバル設定 (`~/.config/mise/config.toml` の `node = "lts"`
-  → 24.14.0) で動作しており、リポジトリ内にバージョン固定が存在しない。
-- 結果として **ローカル node 24.14.0 が、package.json `engines.node >=24.16.0` および
-  CI (`node-version: [24.16.0]`) を満たさずドリフトしている。**
+> 以下の「現状」は本対応 (mise 移行) **前** の状態を指す。本 PR でこれらを解消する。
+
+- 現状 node/pnpm は mise のグローバル設定 (`~/.config/mise/config.toml` の `node = "lts"` → 24.14.0) で動作しており、リポジトリ内にバージョン固定が存在しない。
+- 結果として **ローカル node 24.14.0 が、package.json `engines.node >=24.16.0` およびCI (`node-version: [24.16.0]`) を満たさずドリフトしている。**
 - pnpm はローカル 11.2.2 / CI 11.1.2 / engines `>=11.1.2` と各所でバラついている。
-- apm CLI は `/usr/local/bin/apm` (→ `/usr/local/lib/apm/`) に手動グローバルインストールされ、
-  mise 管轄外。更新は `apm self-update` / `apm doctor` の催促任せ。
+- apm CLI は `/usr/local/bin/apm` (→ `/usr/local/lib/apm/`) に手動グローバルインストールされ、mise 管轄外。更新は `apm self-update` / `apm doctor` の催促任せ。
 - バージョン情報の真実源が「package.json engines」「CI matrix」「各自の環境」に分散している。
 
 ## ゴール
 
 - **`mise.toml` を node / pnpm / apm のバージョン情報の唯一の真実源 (SSoT) とする。**
-- `package.json` の `engines` を削除し、それに依存していた処理 (CI) とドキュメントを
-  mise ベースへ移行する。
+- `package.json` の `engines` を削除し、それに依存していた処理 (CI) とドキュメントを mise ベースへ移行する。
 - ローカルと CI の双方が `mise.toml` に追従する状態にする。
 
 ## 非ゴール / スコープ外
 
-- `scripts/dedupe-apm-lock.mjs` 等の apm **v0.14.1** lock 重複ワークアラウンド
-  (バージョン管理とは別件。0.18.0 で fix 済みかの撤去判断は別 PR とする)。
+- `scripts/dedupe-apm-lock.mjs` 等の apm **v0.14.1** lock 重複ワークアラウンド (バージョン管理とは別件。0.18.0 で fix 済みかの撤去判断は別 PR とする)。
 - `apm.yml` の依存プラグイン (`dependencies.apm`) の SHA ピン運用 (現状維持)。
 
 ## 確定バージョン
 
-| ツール | バージョン | 根拠 |
-| --- | --- | --- |
-| node | `24.16.0` | 24 系最新。旧 `engines.node` / CI matrix と一致 |
-| pnpm | `11.5.2` | 最新。lockfileVersion `9.0` (pnpm 11.x) 互換 |
-| apm  | `0.18.0` | 最新リリース |
+| ツール | バージョン | 根拠                                            |
+| ------ | ---------- | ----------------------------------------------- |
+| node   | `24.16.0`  | 24 系最新。旧 `engines.node` / CI matrix と一致 |
+| pnpm   | `11.5.2`   | 最新。lockfileVersion `9.0` (pnpm 11.x) 互換    |
+| apm    | `0.18.0`   | 最新リリース                                    |
 
-浮動指定 (`"24"` / `"latest"` 等) ではなく **exact ピン**とする。更新は `mise.toml` を編集して
-行う。理由: 本リポジトリの「ドリフト防止 / frozen-lockfile / SHA ピン」文化と整合させ、
-マシン間・時間経過での patch ブレを排除するため。
+浮動指定 (`"24"` / `"latest"` 等) ではなく **exact ピン**とする。更新は `mise.toml` を編集して行う。理由: 本リポジトリの「ドリフト防止 / frozen-lockfile / SHA ピン」文化と整合させ、マシン間・時間経過での patch ブレを排除するため。
 
 ## 設計
 
@@ -50,17 +45,9 @@ pnpm = "11.5.2"
 "github:microsoft/apm" = { version = "0.18.0", extract_all = "true" }
 ```
 
-- apm は mise の **`github` バックエンド**で [microsoft/apm](https://github.com/microsoft/apm)
-  の GitHub Release (`apm-{os}-{arch}.tar.gz`) を取得する。
-- apm は PyInstaller の **onedir** 形式 (実行ファイル `apm` が隣接する `_internal/` を必須とする)。
-  `extract_all = "true"` でアーカイブ全体を展開すると、先頭ディレクトリ (`apm-{os}-{arch}/`) が
-  剥がされて `apm` と `_internal/` が install root に兄弟配置され、mise は bin を install root から
-  解決する。`exe` は**指定しない** (公式ドキュメント上 `extract_all` は `exe` / `rename_exe` と
-  非対応であり、root に実行ファイルは `apm` の1つだけで一意に解決できるため不要)。
-- **検証済み (実機)**: `github` バックエンドは deprecation 警告なしでインストールでき、
-  SLSA provenance / GitHub Artifact Attestations を自動検証し、`apm --version` が
-  正しく動作する (0.17.0 / 0.18.0 とも tarball 構造同一)。`ubi` バックエンドでも動作するが
-  deprecated 警告が出るため不採用。
+- apm は mise の **`github` バックエンド**で [microsoft/apm](https://github.com/microsoft/apm) の GitHub Release (`apm-{os}-{arch}.tar.gz`) を取得する。
+- apm は PyInstaller の **onedir** 形式 (実行ファイル `apm` が隣接する `_internal/` を必須とする)。 `extract_all = "true"` でアーカイブ全体を展開すると、先頭ディレクトリ (`apm-{os}-{arch}/`) が剥がされて `apm` と `_internal/` が install root に兄弟配置され、mise は bin を install root から解決する。`exe` は**指定しない** (公式ドキュメント上 `extract_all` は `exe` / `rename_exe` と非対応であり、root に実行ファイルは `apm` の1つだけで一意に解決できるため不要)。
+- **検証済み (実機)**: `github` バックエンドは deprecation 警告なしでインストールでき、SLSA provenance / GitHub Artifact Attestations を自動検証し、`apm --version` が正しく動作する (0.17.0 / 0.18.0 とも tarball 構造同一)。`ubi` バックエンドでも動作するが deprecated 警告が出るため不採用。
 
 ### 2. `package.json`
 
@@ -71,47 +58,34 @@ pnpm = "11.5.2"
 
 対象: `.github/workflows/deploy.yml`, `.github/workflows/dependency-review.yml`
 
-- `actions/setup-node` と `pnpm/action-setup` のステップを `jdx/mise-action`
-  (コミット SHA ピン + バージョンコメント、本リポジトリの action ピン規約に従う) に置換する。
+- `actions/setup-node` と `pnpm/action-setup` のステップを `jdx/mise-action` (コミット SHA ピン + バージョンコメント、本リポジトリの action ピン規約に従う) に置換する。
 - `node-version` の matrix を撤去する (バージョンは `mise.toml` が決定)。
-- apm は CI で不要 (apm 生成物は `apm.lock.yaml` を除き gitignore 対象) なため、
-  mise-action の導入対象を node / pnpm に限定する (`install_args: "node pnpm"` 相当)。
-  実装時に mise-action の入力名・挙動を公式ドキュメントで確認する。
+- apm は CI で不要 (apm 生成物は `apm.lock.yaml` を除き gitignore 対象) なため、mise-action の導入対象を node / pnpm に限定する (`install_args: "node pnpm"` 相当)。実装時に mise-action の入力名・挙動を公式ドキュメントで確認する。
 - 既存の `pnpm i --frozen-lockfile` / `pnpm run build` 等のステップは維持する。
 - mise-action は新規 `mise.toml` を自動 trust する。
 
 ### 4. ドキュメント
 
-- `.apm/instructions/setup.instructions.md`: 「node と pnpm を `package.json` で指定された
-  バージョンに設定」を **mise ベース手順**へ書き換える。
-  例: `mise trust` (初回) → `mise install` (node/pnpm/apm 導入) → `pnpm i --frozen-lockfile`
-  → `pnpm run dev`。apm も mise 管理になった旨を追記。
+- `.apm/instructions/setup.instructions.md`: 「node と pnpm を `package.json` で指定されたバージョンに設定」を **mise ベース手順**へ書き換える。例: `mise trust` (初回) → `mise install` (node/pnpm/apm 導入) → `pnpm i --frozen-lockfile` → `pnpm run dev`。apm も mise 管理になった旨を追記。
 - `.apm/instructions/github-ops.instructions.md`: CI が mise-action 経由になった旨を反映する。
-- `.apm/instructions/apm-plugins.instructions.md` (または `apm-workflow.instructions.md`):
-  apm CLI 本体の版は `mise.toml` で管理する旨を追記。`apm self-update` や doctor の更新催促では
-  なく、`mise.toml` の版を上げて `mise install` する運用に変更する。
+- `.apm/instructions/apm-plugins.instructions.md` (または `apm-workflow.instructions.md`): apm CLI 本体の版は `mise.toml` で管理する旨を追記。`apm self-update` や doctor の更新催促ではなく、`mise.toml` の版を上げて `mise install` する運用に変更する。
 - `README.md`: バージョン番号の直書きは無いため編集不要 (要確認のみ)。
 
 ## 検証 (実装時に `verification-before-completion` で完遂)
 
 1. `mise trust && mise install` → node 24.16.0 / pnpm 11.5.2 / apm 0.18.0 が導入される。
-2. `which node pnpm apm` が mise 管理下を指す (特に pnpm が node install 配下でなく
-   mise tool であること)。`apm --version` = 0.18.0。
+2. `which node pnpm apm` が mise 管理下を指す (特に pnpm が node install 配下でなく mise tool であること)。`apm --version` = 0.18.0。
 3. `pnpm i --frozen-lockfile` (lockfileVersion 9.0 / pnpm 11.x 互換) → `pnpm run build` 成功。
 4. workflow を push 後、deploy(Build) / dependency-review が green、actionlint パス。
 
 ## リスク / 留意点
 
-- pnpm 11.1.2 → 11.5.2 は同 lockfileVersion 9.0 のため `--frozen-lockfile` 互換見込み。
-  万一不整合なら別途 `pnpm-lock.yaml` の再生成が必要。
-- mise-action 導入は、慎重に組まれた CI に新規 pinned action を 1 つ追加する。
-  SHA ピン + actionlint で担保する。
-- apm の github バックエンドは provenance 検証にネットワーク / gh を用いるが、
-  CI では apm を導入しないため CI への影響は無い。
+- pnpm 11.1.2 → 11.5.2 は同 lockfileVersion 9.0 のため `--frozen-lockfile` 互換見込み。万一不整合なら別途 `pnpm-lock.yaml` の再生成が必要。
+- mise-action 導入は、慎重に組まれた CI に新規 pinned action を 1 つ追加する。SHA ピン + actionlint で担保する。
+- apm の github バックエンドは provenance 検証にネットワーク / gh を用いるが、CI では apm を導入しないため CI への影響は無い。
 
 ## ロールアウト
 
 - 新規ブランチ `chore/mise-version-management` で実装する。
-- 本リポジトリの `local-dev-workflow` (検証 → `requesting-code-review` →
-  `receiving-code-review` → `finishing-a-development-branch` で PR 作成) に従う。
+- 本リポジトリの `local-dev-workflow` (検証 → `requesting-code-review` → `receiving-code-review` → `finishing-a-development-branch` で PR 作成) に従う。
 - コミットに `Co-Authored-By` トレーラは付与しない (本リポジトリ方針)。

--- a/docs/superpowers/specs/2026-06-09-mise-version-management-design.md
+++ b/docs/superpowers/specs/2026-06-09-mise-version-management-design.md
@@ -1,0 +1,115 @@
+# mise によるバージョン管理 (node / pnpm / apm) 設計
+
+- 作成日: 2026-06-09
+- ブランチ: `chore/mise-version-management`
+
+## 背景 / 動機
+
+- 現状 node/pnpm は mise のグローバル設定 (`~/.config/mise/config.toml` の `node = "lts"`
+  → 24.14.0) で動作しており、リポジトリ内にバージョン固定が存在しない。
+- 結果として **ローカル node 24.14.0 が、package.json `engines.node >=24.16.0` および
+  CI (`node-version: [24.16.0]`) を満たさずドリフトしている。**
+- pnpm はローカル 11.2.2 / CI 11.1.2 / engines `>=11.1.2` と各所でバラついている。
+- apm CLI は `/usr/local/bin/apm` (→ `/usr/local/lib/apm/`) に手動グローバルインストールされ、
+  mise 管轄外。更新は `apm self-update` / `apm doctor` の催促任せ。
+- バージョン情報の真実源が「package.json engines」「CI matrix」「各自の環境」に分散している。
+
+## ゴール
+
+- **`mise.toml` を node / pnpm / apm のバージョン情報の唯一の真実源 (SSoT) とする。**
+- `package.json` の `engines` を削除し、それに依存していた処理 (CI) とドキュメントを
+  mise ベースへ移行する。
+- ローカルと CI の双方が `mise.toml` に追従する状態にする。
+
+## 非ゴール / スコープ外
+
+- `scripts/dedupe-apm-lock.mjs` 等の apm **v0.14.1** lock 重複ワークアラウンド
+  (バージョン管理とは別件。0.18.0 で fix 済みかの撤去判断は別 PR とする)。
+- `apm.yml` の依存プラグイン (`dependencies.apm`) の SHA ピン運用 (現状維持)。
+
+## 確定バージョン
+
+| ツール | バージョン | 根拠 |
+| --- | --- | --- |
+| node | `24.16.0` | 24 系最新。旧 `engines.node` / CI matrix と一致 |
+| pnpm | `11.5.2` | 最新。lockfileVersion `9.0` (pnpm 11.x) 互換 |
+| apm  | `0.18.0` | 最新リリース |
+
+浮動指定 (`"24"` / `"latest"` 等) ではなく **exact ピン**とする。更新は `mise.toml` を編集して
+行う。理由: 本リポジトリの「ドリフト防止 / frozen-lockfile / SHA ピン」文化と整合させ、
+マシン間・時間経過での patch ブレを排除するため。
+
+## 設計
+
+### 1. `mise.toml` (新規・リポジトリ直下・git 追跡)
+
+```toml
+[tools]
+node = "24.16.0"
+pnpm = "11.5.2"
+"github:microsoft/apm" = { version = "0.18.0", exe = "apm", extract_all = "true" }
+```
+
+- apm は mise の **`github` バックエンド**で [microsoft/apm](https://github.com/microsoft/apm)
+  の GitHub Release (`apm-{os}-{arch}.tar.gz`) を取得する。
+- apm は PyInstaller の **onedir** 形式 (実行ファイル `apm` が隣接する `_internal/` を必須とする)。
+  `extract_all = "true"` でアーカイブ全体を展開し `apm` と `_internal/` を兄弟配置、
+  `exe = "apm"` で起動エントリを指定する。
+- **検証済み (実機)**: `github` バックエンドは deprecation 警告なしでインストールでき、
+  SLSA provenance / GitHub Artifact Attestations を自動検証し、`apm --version` が
+  正しく動作する (0.17.0 / 0.18.0 とも tarball 構造同一)。`ubi` バックエンドでも動作するが
+  deprecated 警告が出るため不採用。
+
+### 2. `package.json`
+
+- `engines` (node / pnpm) ブロックを削除する。
+- `.npmrc` の `engine-strict` は存在しないため、削除による pnpm 実行時の挙動変化は無い。
+
+### 3. CI — `jdx/mise-action` で SSoT 追従
+
+対象: `.github/workflows/deploy.yml`, `.github/workflows/dependency-review.yml`
+
+- `actions/setup-node` と `pnpm/action-setup` のステップを `jdx/mise-action`
+  (コミット SHA ピン + バージョンコメント、本リポジトリの action ピン規約に従う) に置換する。
+- `node-version` の matrix を撤去する (バージョンは `mise.toml` が決定)。
+- apm は CI で不要 (apm 生成物は `apm.lock.yaml` を除き gitignore 対象) なため、
+  mise-action の導入対象を node / pnpm に限定する (`install_args: "node pnpm"` 相当)。
+  実装時に mise-action の入力名・挙動を公式ドキュメントで確認する。
+- 既存の `pnpm i --frozen-lockfile` / `pnpm run build` 等のステップは維持する。
+- mise-action は新規 `mise.toml` を自動 trust する。
+
+### 4. ドキュメント
+
+- `.apm/instructions/setup.instructions.md`: 「node と pnpm を `package.json` で指定された
+  バージョンに設定」を **mise ベース手順**へ書き換える。
+  例: `mise trust` (初回) → `mise install` (node/pnpm/apm 導入) → `pnpm i --frozen-lockfile`
+  → `pnpm run dev`。apm も mise 管理になった旨を追記。
+- `.apm/instructions/github-ops.instructions.md`: CI が mise-action 経由になった旨を反映する。
+- `.apm/instructions/apm-plugins.instructions.md` (または `apm-workflow.instructions.md`):
+  apm CLI 本体の版は `mise.toml` で管理する旨を追記。`apm self-update` や doctor の更新催促では
+  なく、`mise.toml` の版を上げて `mise install` する運用に変更する。
+- `README.md`: バージョン番号の直書きは無いため編集不要 (要確認のみ)。
+
+## 検証 (実装時に `verification-before-completion` で完遂)
+
+1. `mise trust && mise install` → node 24.16.0 / pnpm 11.5.2 / apm 0.18.0 が導入される。
+2. `which node pnpm apm` が mise 管理下を指す (特に pnpm が node install 配下でなく
+   mise tool であること)。`apm --version` = 0.18.0。
+3. `pnpm i --frozen-lockfile` (lockfileVersion 9.0 / pnpm 11.x 互換) → `pnpm run build` 成功。
+4. workflow を push 後、deploy(Build) / dependency-review が green、actionlint パス。
+
+## リスク / 留意点
+
+- pnpm 11.1.2 → 11.5.2 は同 lockfileVersion 9.0 のため `--frozen-lockfile` 互換見込み。
+  万一不整合なら別途 `pnpm-lock.yaml` の再生成が必要。
+- mise-action 導入は、慎重に組まれた CI に新規 pinned action を 1 つ追加する。
+  SHA ピン + actionlint で担保する。
+- apm の github バックエンドは provenance 検証にネットワーク / gh を用いるが、
+  CI では apm を導入しないため CI への影響は無い。
+
+## ロールアウト
+
+- 新規ブランチ `chore/mise-version-management` で実装する。
+- 本リポジトリの `local-dev-workflow` (検証 → `requesting-code-review` →
+  `receiving-code-review` → `finishing-a-development-branch` で PR 作成) に従う。
+- コミットに `Co-Authored-By` トレーラは付与しない (本リポジトリ方針)。

--- a/docs/superpowers/specs/2026-06-09-mise-version-management-design.md
+++ b/docs/superpowers/specs/2026-06-09-mise-version-management-design.md
@@ -47,14 +47,16 @@
 [tools]
 node = "24.16.0"
 pnpm = "11.5.2"
-"github:microsoft/apm" = { version = "0.18.0", exe = "apm", extract_all = "true" }
+"github:microsoft/apm" = { version = "0.18.0", extract_all = "true" }
 ```
 
 - apm は mise の **`github` バックエンド**で [microsoft/apm](https://github.com/microsoft/apm)
   の GitHub Release (`apm-{os}-{arch}.tar.gz`) を取得する。
 - apm は PyInstaller の **onedir** 形式 (実行ファイル `apm` が隣接する `_internal/` を必須とする)。
-  `extract_all = "true"` でアーカイブ全体を展開し `apm` と `_internal/` を兄弟配置、
-  `exe = "apm"` で起動エントリを指定する。
+  `extract_all = "true"` でアーカイブ全体を展開すると、先頭ディレクトリ (`apm-{os}-{arch}/`) が
+  剥がされて `apm` と `_internal/` が install root に兄弟配置され、mise は bin を install root から
+  解決する。`exe` は**指定しない** (公式ドキュメント上 `extract_all` は `exe` / `rename_exe` と
+  非対応であり、root に実行ファイルは `apm` の1つだけで一意に解決できるため不要)。
 - **検証済み (実機)**: `github` バックエンドは deprecation 警告なしでインストールでき、
   SLSA provenance / GitHub Artifact Attestations を自動検証し、`apm --version` が
   正しく動作する (0.17.0 / 0.18.0 とも tarball 構造同一)。`ubi` バックエンドでも動作するが

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+node = "24.16.0"
+pnpm = "11.5.2"
+"github:microsoft/apm" = { version = "0.18.0", extract_all = "true" }

--- a/package.json
+++ b/package.json
@@ -24,10 +24,6 @@
 		"prepare": "husky",
 		"apm-install": "apm install && node scripts/dedupe-apm-lock.mjs"
 	},
-	"engines": {
-		"node": ">=24.16.0",
-		"pnpm": ">=11.1.2"
-	},
 	"husky": {
 		"hooks": {
 			"pre-commit": "lint-staged"


### PR DESCRIPTION
## 期待する挙動・状態

`mise.toml` を node / pnpm / apm のバージョン情報の唯一の真実源 (SSoT) とし、`package.json` の `engines` を撤去、ローカルと CI を mise ベースに統一する。

**本 PR のスコープ (設計 + 実装の両方を含む)**:

- 設計/計画ドキュメント: `docs/superpowers/specs/2026-06-09-mise-version-management-design.md`, `docs/superpowers/plans/2026-06-09-mise-version-management.md`
- 実装:
  - `mise.toml` 追加 (node `24.16.0` / pnpm `11.5.2` / `github:microsoft/apm` `0.18.0`, `extract_all="true"`)
  - `package.json` の `engines` 削除
  - CI (`deploy.yml` / `dependency-review.yml`) を `jdx/mise-action` (SHA ピン・`version: 2026.6.1`・`install_args: "node pnpm"`) に置換、`node-version` matrix 撤去
  - 関連ドキュメント (`setup` / `github-ops` / `apm-workflow` instructions) を mise ベースへ更新

> 注: 当初は「設計ドキュメントのみ」で PR を開き、実装を本ブランチに追加コミットしていく方針としていた。実装が出揃ったため本説明を「設計 + 実装」に更新済み。

## 必要な依存関係

- ローカル: [mise](https://mise.jdx.dev/) (>= 2026.6.1)。Linux では pnpm (Node SEA) が `libatomic.so.1` を要するため `libatomic1` を導入。
- CI: `jdx/mise-action` (リポジトリの Allowed actions に `jdx/mise-action@*` を追加済み)。

## 確認済み項目

- [x] ローカル: `mise install` で node 24.16.0 / pnpm 11.5.2 / apm 0.18.0 解決、`apm --version`=0.18.0、`tsc -b --force` exit 0 (node 24.16.0 でクリーンビルド)
- [x] CI: `Dependency Check / Build-Check` が mise-action 経由で `pnpm i --frozen-lockfile` → `pnpm run build` を通過 (npmjs.org)。`Dependency-Review` / `CodeQL` / `DeepScan` / `Snyk` も pass
- [x] 両 workflow は actionlint 通過
- [x] `extract_all = "true"` (クォート文字列) は mise 公式表記・`exe` は extract_all と非互換のため不指定 (実機検証済み)

## 見てほしいところ

- [ ] PRのLabelsの設定は適切か (ツール/バージョン管理のため `dependencies` を付与)
- [ ] 設計方針 (SSoT 化 / CI を mise-action へ / 確定バージョン) に異論がないか
