### PR TITLE
apm.yml と package.json の description を日本語に統一

### DIFF
--- a/apm.yml
+++ b/apm.yml
@@ -1,6 +1,6 @@
 name: bingo-machine
 version: 2.0.1
-description: AI agent instructions for the Bingo Machine project
+description: Bingo Machine プロジェクトの AI エージェント向け指示
 author: ROhta
 license: GPL-3.0-or-later
 type: instructions

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "bingo-machine",
 	"version": "2.0.1",
 	"author": "ROhta",
-	"description": "A Bingo Machine for Party",
+	"description": "パーティ向けビンゴ抽選機",
 	"private": false,
 	"license": "GPL-3.0-or-later",
 	"homepage": "https://rohta.github.io/bingo/",


### PR DESCRIPTION
## 期待する挙動・状態

- `apm.yml` / `package.json` の `description` が英語表記のまま残っていたため、リポジトリ全体の日本語表記に統一する
  - `apm.yml`: `AI agent instructions for the Bingo Machine project` → `Bingo Machine プロジェクトの AI エージェント向け指示`
  - `package.json`: `A Bingo Machine for Party` → `パーティ向けビンゴ抽選機`
- 訳語は README の表記 (「AI エージェント向け指示」「パーティ向けビンゴ抽選機」) に揃えた

## 必要な依存関係

- なし

## 確認済み項目

- [x] `package.json` が JSON として妥当であること (`node -e "require('./package.json')"`)
- [x] lint-staged (prettier) が通過すること

## 見てほしいところ

- [x] PRのLabelsの設定は適切か (`bug-3 改善` = 割れ窓修正として付与)
- [x] 日本語訳が README の用語と整合しているか