### PR TITLE
fix(ci): Pages デプロイを直列化して in-progress 衝突を防ぐ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,12 @@ defaults:
   run:
     shell: bash
 
-# ワークフローが複数起動したら自動キャンセル
+# Pages のデプロイ先はリポジトリで1つのため全体で直列化する。
+# 進行中の実行をキャンセルすると Pages 側のデプロイが孤立して後続が
+# "in progress deployment" で 400 になるため、cancel-in-progress は false にする。
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   Build:


### PR DESCRIPTION
## 背景

`Deploy pages` ワークフロー（run [#28649926690](https://github.com/ROhta/bingo/actions/runs/28649926690)）の Deploy ジョブが以下のエラーで失敗した。

```
Failed to create deployment (status: 400) ... due to in progress deployment.
Please cancel ac490cb7ea4c8cb2596e18f6be04266cf2ad4ce9 first or wait for it to complete.
```

## 原因

既存の concurrency 設定が `cancel-in-progress: true` だった。これは新しい push が来ると**古いワークフロー実行**をキャンセルするが、その実行が既に作成した **GitHub Pages 側のデプロイ**は「進行中」のまま残る。次の実行が `deploy-pages` に到達すると、その孤立デプロイと衝突して 400 になる。

## 変更

GitHub 公式の Pages スターターワークフローに合わせ、進行中のデプロイを殺さずに直列化する設定へ変更。

- `group: ${{ github.workflow }}-${{ github.ref }}` → `group: "pages"`
  （`workflow_dispatch` を別ブランチから実行しても ref に依らず全体で直列化されるように）
- `cancel-in-progress: true` → `false`
  （進行中の Pages デプロイを完了させ、後続はキューで待つ）

## 動作

burst push 時も各実行が順番に完走し、"in progress deployment" 衝突が発生しなくなる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDpYWbQpcKMxYgACPjpwMQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by ensuring GitHub Pages publishes run one at a time.
  * Prevented in-progress deployments from being canceled by newer runs, reducing the chance of interrupted releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->