### PR TITLE
chore(mise): node と pnpm を最新版に更新

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -15,27 +15,27 @@ url = "https://github.com/microsoft/apm/releases/download/v0.24.0/apm-darwin-arm
 url_api = "https://api.github.com/repos/microsoft/apm/releases/assets/467124802"
 
 [[tools.node]]
-version = "24.16.0"
+version = "24.18.0"
 backend = "core:node"
 
 [tools.node."platforms.linux-x64"]
-checksum = "sha256:2faf6a387e9b62b888e21c54f01249fb27537ffecf1842f29f4c919d0a59a0ff"
-url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-linux-x64.tar.gz"
+checksum = "sha256:783130984963db7ba9cbd01089eaf2c2efb055c7c1693c943174b967b3050cb8"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-x64.tar.gz"
 
 [tools.node."platforms.macos-arm64"]
-checksum = "sha256:39189dab4eeb15706c424af0ac08a3044c9e48f7db12a7d77f6b7aafc7dd5df6"
-url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-darwin-arm64.tar.gz"
+checksum = "sha256:e1a97e14c99c803e96c7339403282ea05a499c32f8d83defe9ef5ec66f979ed1"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-darwin-arm64.tar.gz"
 
 [[tools.pnpm]]
-version = "11.5.2"
+version = "11.10.0"
 backend = "aqua:pnpm/pnpm"
 
 [tools.pnpm."platforms.linux-x64"]
-checksum = "sha256:2033a702618c8576dc6bb0f6adb3a67ab506031351ddd59ca50d1bcaf5d13dc5"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.5.2/pnpm-linux-x64.tar.gz"
+checksum = "sha256:cf22c9f1ba90f67c9a5cfb1cbe9c2087cf4c3a5c409dad738c1f8a38b8137666"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.10.0/pnpm-linux-x64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pnpm."platforms.macos-arm64"]
-checksum = "sha256:54993dae26bea0f3c1b0e15f9427f6f6a86827d56f32d1d1554d8cda59a62399"
-url = "https://github.com/pnpm/pnpm/releases/download/v11.5.2/pnpm-darwin-arm64.tar.gz"
+checksum = "sha256:d0d8a55b47dbe07a80d13fec7ee5af9bdca36187e61f9562d72d81dd637178c4"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.10.0/pnpm-darwin-arm64.tar.gz"
 provenance = "github-attestations"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
-node = "24.16.0"
-pnpm = "11.5.2"
+node = "24.18.0"
+pnpm = "11.10.0"
 "github:microsoft/apm" = { version = "0.24.0", extract_all = "true" }
 
 [settings]


### PR DESCRIPTION
## 期待する挙動・状態

- `mise.toml` が管理する node / pnpm が最新版で記述され、`mise.lock` が両プラットフォーム（linux-x64 / macos-arm64）で整合している状態。
- CI（`jdx/mise-action`）・ローカルとも、更新後のツールチェーンでビルド / lint / install が従来どおり動作すること。

## 必要な依存関係

- なし（`mise.toml` / `mise.lock` のツールバージョン更新のみ）

更新内容:

- node 24.16.0 → 24.18.0（**最新 LTS**。文字通りの最新は current 26.4.0 だが、非 LTS のため不採用）
- pnpm 11.5.2 → 11.10.0（同一メジャー・マイナーアップ）
- `github:microsoft/apm` は 0.24.0 で**既に最新**のため据え置き（#390 で更新済み）
- `mise.lock` を `mise lock --platform linux-x64,macos-arm64` で**両プラットフォーム**再生成

## 確認済み項目

- [x] node / pnpm / apm の最新版を `mise latest` / `gh release list` で確認（node は LTS=24.18.0 と current=26.4.0 を区別のうえ LTS を採用）
- [x] `mise.lock` を両プラットフォームで再生成（#390 の片肺更新による Build-Check 失敗を回避）
- [x] `mise exec -- pnpm install --frozen-lockfile` が成功し、pnpm 11.10.0 で `pnpm-lock.yaml` がドリフトしない（無変更）ことを確認
- [x] node 24.18.0 で `pnpm run build`（tsc -b）/ `eslint src` / `prettier --check`（主要ソース）が成功

## 見てほしいところ

- [x] PR の Labels の設定は適切か（`dependencies` を付与）
- [ ] node の LTS 選択（24.18.0）で問題ないか。本プロジェクトは node をビルド時（tsc）のみ使用するため、安定性を優先して最新 current(26.4.0) ではなく最新 LTS を採用した
- [ ] `mise.lock` の両プラットフォーム checksum が正しく更新されているか（node / pnpm とも linux-x64・macos-arm64 を更新、apm 0.24.0 は据え置き、pnpm の `provenance = "github-attestations"` も維持）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned Node.js and pnpm versions to newer releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->