### PR TITLE
docs(setup): mise 下限要件の注記を pnpm 11.5.2 以降に一般化

### DIFF
--- a/.apm/instructions/setup.instructions.md
+++ b/.apm/instructions/setup.instructions.md
@@ -21,4 +21,4 @@ applyTo: "**/{mise.toml,package.json,pnpm-lock.yaml,tsconfig.json}"
 
 ## バージョン管理 (mise)
 
-node / pnpm / apm CLI 本体のバージョンは `mise.toml` を唯一の真実源 (SSoT) とする。バージョンを上げる際は `mise.toml` を編集して `mise install` する (apm の `apm self-update` や `apm doctor` の更新催促には従わない)。CI も `jdx/mise-action` (mise 本体は `version: 2026.6.1` にピン) 経由で同じ `mise.toml` を消費する。mise 本体は最低 2026.6.1 を要する (これ未満では pnpm 11.5.2 の aqua アセット解決に失敗する)。
+node / pnpm / apm CLI 本体のバージョンは `mise.toml` を唯一の真実源 (SSoT) とする。バージョンを上げる際は `mise.toml` を編集して `mise install` する (apm の `apm self-update` や `apm doctor` の更新催促には従わない)。CI も `jdx/mise-action` (mise 本体は `version: 2026.6.1` にピン) 経由で同じ `mise.toml` を消費する。mise 本体は最低 2026.6.1 を要する (これ未満では pnpm 11.5.2 以降の aqua アセット解決に失敗する)。


### PR DESCRIPTION
## 期待する挙動・状態

- 環境構築 instructions（SoT: `.apm/instructions/setup.instructions.md`）の mise バージョン下限要件の注記が、現行 pnpm（11.10.0、#392 で更新）にも正しく当てはまる記述になっている状態。

## 必要な依存関係

- なし（instructions の 1 行の文言修正のみ）

変更内容:

- 「これ未満では pnpm 11.5.2 の aqua アセット解決に失敗する」→「これ未満では pnpm 11.5.2 **以降**の aqua アセット解決に失敗する」

## 確認済み項目

- [x] 編集対象が SoT の `.apm/instructions/setup.instructions.md` のみで、生成物（`.claude/rules/setup.md` / `.github/instructions/setup.instructions.md`）は gitignore 対象のためコミットに含まれないことを確認
- [x] `apm install` は実行していない（生成物は次回 install で SoT から追従。`sessionStart` フック再注入等の副作用を避けるため）

## 見てほしいところ

- [x] PR の Labels の設定は適切か（`enhance-3 ドキュメント` を付与）
- [ ] 文言「pnpm 11.5.2 以降」で妥当か。mise 2026.6.1 の下限要件は pnpm 11.5.x で導入されたため版番号アンカーは残しつつ「以降」で 11.10.0 も包含する意図（版番号を削除すると全 pnpm 版が下限を要すると誤読、11.10.0 固定だと下限を 11.10.0 と誤認するため、この表現を選択）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the setup instructions for version management requirements.
  * Updated the failure message guidance so it matches the current supported tool version more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->