### PR TITLE
chore(gitignore): tsconfig.tsbuildinfo を追跡対象外に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 src/js/*
+*.tsbuildinfo
 .vscode/settings.json
 .vscode/chrome-debug-profile/
 .vscode/edge-debug-profile/


### PR DESCRIPTION
## 期待する挙動・状態

- `tsc -b` が生成する incremental build 成果物（`*.tsbuildinfo`）が git の追跡対象外となり、`git add -A` 等で誤ってコミットされない状態。

## 必要な依存関係

- なし（`.gitignore` に 1 行追加のみ）

変更内容:

- `.gitignore` の先頭セクション（`src/js/*` 等 tsc 出力の近く）に `*.tsbuildinfo` を追加

## 確認済み項目

- [x] `git check-ignore tsconfig.tsbuildinfo` がパスを返し、ignore が効くことを確認
- [x] `git status` で `tsconfig.tsbuildinfo` が未追跡（`??`）一覧から消えることを確認

## 見てほしいところ

- [x] PR の Labels の設定は適切か（`refactor` を付与）
- [ ] パターンを `*.tsbuildinfo`（汎用）とした点。tsconfig 名に依存して生成される `<name>.tsbuildinfo` も含めてカバーする意図（`tsconfig.tsbuildinfo` 決め打ちより堅牢）で問題ないか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignored files to include TypeScript build artifacts, helping keep generated files out of version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->